### PR TITLE
Limit features for private projects

### DIFF
--- a/client/src/components/board-memberships/BoardMemberships/AddStep/AddStep.jsx
+++ b/client/src/components/board-memberships/BoardMemberships/AddStep/AddStep.jsx
@@ -25,8 +25,9 @@ const StepTypes = {
 const AddStep = React.memo(({ onClose }) => {
   const users = useSelector((state) => {
     const user = selectors.selectCurrentUser(state);
+    const project = selectors.selectCurrentProject(state);
 
-    if (!isUserAdminOrProjectOwner(user)) {
+    if (!isUserAdminOrProjectOwner(user) || project.ownerProjectManagerId) {
       return [user];
     }
 

--- a/client/src/components/board-memberships/BoardMemberships/BoardMemberships.jsx
+++ b/client/src/components/board-memberships/BoardMemberships/BoardMemberships.jsx
@@ -21,11 +21,6 @@ import styles from './BoardMemberships.module.scss';
 const BoardMemberships = React.memo(() => {
   const boardMemberships = useSelector(selectors.selectMembershipsForCurrentBoard);
   const { ownerProjectManagerId } = useSelector(selectors.selectCurrentProject);
-
-  if (ownerProjectManagerId) {
-    return null;
-  }
-
   const canAdd = useSelector((state) => {
     const user = selectors.selectCurrentUser(state);
 
@@ -42,6 +37,10 @@ const BoardMemberships = React.memo(() => {
   );
 
   const AddPopup = usePopup(AddStep);
+
+  if (ownerProjectManagerId) {
+    return null;
+  }
 
   return (
     <>

--- a/client/src/components/board-memberships/BoardMemberships/BoardMemberships.jsx
+++ b/client/src/components/board-memberships/BoardMemberships/BoardMemberships.jsx
@@ -20,6 +20,11 @@ import styles from './BoardMemberships.module.scss';
 
 const BoardMemberships = React.memo(() => {
   const boardMemberships = useSelector(selectors.selectMembershipsForCurrentBoard);
+  const { ownerProjectManagerId } = useSelector(selectors.selectCurrentProject);
+
+  if (ownerProjectManagerId) {
+    return null;
+  }
 
   const canAdd = useSelector((state) => {
     const user = selectors.selectCurrentUser(state);

--- a/client/src/components/boards/BoardActions/BoardActions.jsx
+++ b/client/src/components/boards/BoardActions/BoardActions.jsx
@@ -15,6 +15,8 @@ import BoardMemberships from '../../board-memberships/BoardMemberships';
 import styles from './BoardActions.module.scss';
 
 const BoardActions = React.memo(() => {
+  const { ownerProjectManagerId } = useSelector(selectors.selectCurrentProject);
+
   const withMemberships = useSelector((state) => {
     const boardMemberships = selectors.selectMembershipsForCurrentBoard(state);
 
@@ -25,10 +27,12 @@ const BoardActions = React.memo(() => {
     return selectors.selectIsCurrentUserManagerForCurrentProject(state);
   });
 
+  const showMemberships = withMemberships && !ownerProjectManagerId;
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.actions}>
-        {withMemberships && (
+        {showMemberships && (
           <div className={styles.action}>
             <BoardMemberships />
           </div>

--- a/client/src/components/boards/BoardActions/Filters.jsx
+++ b/client/src/components/boards/BoardActions/Filters.jsx
@@ -144,36 +144,40 @@ const Filters = React.memo(() => {
 
   const BoardMembershipsPopup = usePopup(BoardMembershipsStep);
   const LabelsPopup = usePopup(LabelsStep);
-
+  const { ownerProjectManagerId } = useSelector(selectors.selectCurrentProject);
   const isSearchActive = search || isSearchFocused;
 
   return (
     <>
-      <span className={styles.filter}>
-        <BoardMembershipsPopup
-          currentUserIds={userIds}
-          title="common.filterByMembers"
-          onUserSelect={handleUserSelect}
-          onUserDeselect={handleUserDeselect}
-        >
-          <button type="button" className={styles.filterButton}>
-            <span className={styles.filterTitle}>{`${t('common.members')}:`}</span>
-            {userIds.length === 0 && <span className={styles.filterLabel}>{t('common.all')}</span>}
-          </button>
-        </BoardMembershipsPopup>
-        {userIds.length === 0 && withCurrentUserSelector && (
-          <button type="button" className={styles.filterButton} onClick={handleCurrentUserSelect}>
-            <span className={styles.filterLabel}>
-              <Icon fitted name="target" className={styles.filterLabelIcon} />
+      {!ownerProjectManagerId && (
+        <span className={styles.filter}>
+          <BoardMembershipsPopup
+            currentUserIds={userIds}
+            title="common.filterByMembers"
+            onUserSelect={handleUserSelect}
+            onUserDeselect={handleUserDeselect}
+          >
+            <button type="button" className={styles.filterButton}>
+              <span className={styles.filterTitle}>{`${t('common.members')}:`}</span>
+              {userIds.length === 0 && (
+                <span className={styles.filterLabel}>{t('common.all')}</span>
+              )}
+            </button>
+          </BoardMembershipsPopup>
+          {userIds.length === 0 && withCurrentUserSelector && (
+            <button type="button" className={styles.filterButton} onClick={handleCurrentUserSelect}>
+              <span className={styles.filterLabel}>
+                <Icon fitted name="target" className={styles.filterLabelIcon} />
+              </span>
+            </button>
+          )}
+          {userIds.map((userId) => (
+            <span key={userId} className={styles.filterItem}>
+              <UserAvatar id={userId} size="tiny" onClick={handleUserClick} />
             </span>
-          </button>
-        )}
-        {userIds.map((userId) => (
-          <span key={userId} className={styles.filterItem}>
-            <UserAvatar id={userId} size="tiny" onClick={handleUserClick} />
-          </span>
-        ))}
-      </span>
+          ))}
+        </span>
+      )}
       <span className={styles.filter}>
         <LabelsPopup
           currentIds={labelIds}

--- a/client/src/components/project-managers/ProjectManagers/ProjectManagers.jsx
+++ b/client/src/components/project-managers/ProjectManagers/ProjectManagers.jsx
@@ -20,10 +20,6 @@ const ProjectManagers = React.memo(() => {
   const projectManagers = useSelector(selectors.selectManagersForCurrentProject);
   const { ownerProjectManagerId } = useSelector(selectors.selectCurrentProject);
 
-  if (ownerProjectManagerId) {
-    return null;
-  }
-
   const canAdd = useSelector((state) => {
     const user = selectors.selectCurrentUser(state);
 
@@ -36,6 +32,10 @@ const ProjectManagers = React.memo(() => {
 
   const AddPopup = usePopupInClosableContext(AddStep);
   const ActionsPopup = usePopupInClosableContext(ActionsStep);
+
+  if (ownerProjectManagerId) {
+    return null;
+  }
 
   return (
     <div className={styles.wrapper}>

--- a/client/src/components/project-managers/ProjectManagers/ProjectManagers.jsx
+++ b/client/src/components/project-managers/ProjectManagers/ProjectManagers.jsx
@@ -18,6 +18,11 @@ import styles from './ProjectManagers.module.scss';
 
 const ProjectManagers = React.memo(() => {
   const projectManagers = useSelector(selectors.selectManagersForCurrentProject);
+  const { ownerProjectManagerId } = useSelector(selectors.selectCurrentProject);
+
+  if (ownerProjectManagerId) {
+    return null;
+  }
 
   const canAdd = useSelector((state) => {
     const user = selectors.selectCurrentUser(state);

--- a/server/api/controllers/board-memberships/create.js
+++ b/server/api/controllers/board-memberships/create.js
@@ -69,6 +69,10 @@ module.exports = {
       throw Errors.BOARD_NOT_FOUND; // Forbidden
     }
 
+    if (project.ownerProjectManagerId && inputs.userId !== currentUser.id) {
+      throw Errors.NOT_ENOUGH_RIGHTS;
+    }
+
     if (!sails.helpers.users.isAdminOrProjectOwner(currentUser)) {
       if (inputs.userId !== currentUser.id) {
         throw Errors.NOT_ENOUGH_RIGHTS;


### PR DESCRIPTION
## Summary
- restrict adding board members to current user for private projects
- hide board member UI on private projects
- hide project manager list on private projects

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8e0c84508323bf63ad4a578b3afb