### PR TITLE
Add option to revert shared project to private

### DIFF
--- a/client/src/components/projects/ProjectSettingsModal/ManagersPane.jsx
+++ b/client/src/components/projects/ProjectSettingsModal/ManagersPane.jsx
@@ -18,9 +18,26 @@ import styles from './ManagersPane.module.scss';
 
 const ManagersPane = React.memo(() => {
   // TODO: rename?
+  const projectManagers = useSelector(selectors.selectManagersForCurrentProject);
+  const managerUserIds = useSelector(
+    selectors.selectManagerUserIdsForCurrentProject,
+  );
+  const memberUserIds = useSelector(
+    selectors.selectMemberUserIdsForCurrentProject,
+  );
+  const currentUserId = useSelector(selectors.selectCurrentUserId);
+
   const isShared = useSelector(
     (state) => !selectors.selectCurrentProject(state).ownerProjectManagerId,
   );
+
+  const canMakePrivate =
+    isShared &&
+    projectManagers.length === 1 &&
+    managerUserIds.length === 1 &&
+    memberUserIds.length === 1 &&
+    managerUserIds[0] === currentUserId &&
+    memberUserIds[0] === currentUserId;
 
   const dispatch = useDispatch();
   const [t] = useTranslation();
@@ -32,6 +49,16 @@ const ManagersPane = React.memo(() => {
       }),
     );
   }, [dispatch]);
+
+  const handleMakePrivateConfirm = useCallback(() => {
+    if (projectManagers.length > 0) {
+      dispatch(
+        entryActions.updateCurrentProject({
+          ownerProjectManagerId: projectManagers[0].id,
+        }),
+      );
+    }
+  }, [dispatch, projectManagers]);
 
   const ConfirmationPopup = usePopupInClosableContext(ConfirmationStep);
 
@@ -57,6 +84,32 @@ const ManagersPane = React.memo(() => {
             >
               <Button className={styles.actionButton}>
                 {t('action.makeProjectShared', {
+                  context: 'title',
+                })}
+              </Button>
+            </ConfirmationPopup>
+          </div>
+        </>
+      )}
+      {canMakePrivate && (
+        <>
+          <Divider horizontal section>
+            <Header as="h4">
+              {t('common.dangerZone', {
+                context: 'title',
+              })}
+            </Header>
+          </Divider>
+          <div className={styles.action}>
+            <ConfirmationPopup
+              title="common.makeProjectPrivate"
+              content="common.areYouSureYouWantToMakeThisProjectPrivate"
+              buttonType="negative"
+              buttonContent="action.makeProjectPrivate"
+              onConfirm={handleMakePrivateConfirm}
+            >
+              <Button className={styles.actionButton}>
+                {t('action.makeProjectPrivate', {
                   context: 'title',
                 })}
               </Button>

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -71,6 +71,8 @@ export default {
       areYouSureYouWantToLeaveProject: 'Are you sure you want to leave the project?',
       areYouSureYouWantToMakeThisProjectShared:
         'Are you sure you want to make this project shared?',
+      areYouSureYouWantToMakeThisProjectPrivate:
+        'Are you sure you want to make this project private?',
       areYouSureYouWantToRemoveThisManagerFromProject:
         'Are you sure you want to remove this manager from the project?',
       areYouSureYouWantToRemoveThisMemberFromBoard:
@@ -205,6 +207,7 @@ export default {
       listActions_title: 'List Actions',
       lists: 'Lists',
       makeProjectShared_title: 'Make Project Shared',
+      makeProjectPrivate_title: 'Make Project Private',
       managers: 'Managers',
       memberActions_title: 'Member Actions',
       members: 'Members',
@@ -410,6 +413,8 @@ export default {
       makeCover_title: 'Make Cover',
       makeProjectShared: 'Make project shared',
       makeProjectShared_title: 'Make Project Shared',
+      makeProjectPrivate: 'Make project private',
+      makeProjectPrivate_title: 'Make Project Private',
       move: 'Move',
       moveCard_title: 'Move Card',
       remove: 'Remove',

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -78,6 +78,8 @@ export default {
       areYouSureYouWantToLeaveProject: 'Êtes-vous sûr de vouloir quitter ce projet ?',
       areYouSureYouWantToMakeThisProjectShared:
         "Etes-vous sûr de vouloir transformer ce projet en projet d'équipe ?",
+      areYouSureYouWantToMakeThisProjectPrivate:
+        'Êtes-vous sûr de vouloir transformer ce projet en projet privé ?',
       areYouSureYouWantToRemoveThisManagerFromProject:
         'Êtes-vous sûr de vouloir supprimer ce responsable du projet ?',
       areYouSureYouWantToRemoveThisMemberFromBoard:
@@ -214,6 +216,7 @@ export default {
       listActions_title: 'Liste des actions',
       lists: 'Listes',
       makeProjectShared_title: 'Transformer le projet en projet partagé',
+      makeProjectPrivate_title: 'Transformer le projet en projet privé',
       managers: 'Responsables',
       memberActions_title: 'Actions des membres',
       members: 'Membres',
@@ -419,6 +422,8 @@ export default {
       makeCover_title: 'Faire la couverture',
       makeProjectShared: "Transformer le projet en projet d'équipe",
       makeProjectShared_title: "Transformer le projet en projet d'équipe",
+      makeProjectPrivate: 'Transformer le projet en projet privé',
+      makeProjectPrivate_title: 'Transformer le projet en projet privé',
       move: 'Déplacer',
       moveCard_title: 'Déplacer la carte',
       remove: 'Supprimer',

--- a/client/src/selectors/projects.js
+++ b/client/src/selectors/projects.js
@@ -202,6 +202,38 @@ export const selectManagerUserIdsForCurrentProject = createSelector(
   },
 );
 
+export const selectMemberUserIdsForCurrentProject = createSelector(
+  orm,
+  (state) => selectPath(state).projectId,
+  ({ Project }, id) => {
+    if (!id) {
+      return id;
+    }
+
+    const projectModel = Project.withId(id);
+
+    if (!projectModel) {
+      return projectModel;
+    }
+
+    const userIdSet = new Set();
+
+    projectModel
+      .getBoardsQuerySet()
+      .toModelArray()
+      .forEach((boardModel) => {
+        boardModel
+          .getMembershipsQuerySet()
+          .toRefArray()
+          .forEach((membership) => {
+            userIdSet.add(membership.userId);
+          });
+      });
+
+    return Array.from(userIdSet);
+  },
+);
+
 export const selectBackgroundImageIdsForCurrentProject = createSelector(
   orm,
   (state) => selectPath(state).projectId,
@@ -326,6 +358,7 @@ export default {
   selectCurrentProject,
   selectManagersForCurrentProject,
   selectManagerUserIdsForCurrentProject,
+  selectMemberUserIdsForCurrentProject,
   selectBackgroundImageIdsForCurrentProject,
   selectBaseCustomFieldGroupIdsForCurrentProject,
   selectBaseCustomFieldGroupsForCurrentProject,


### PR DESCRIPTION
## Summary
- compute project participant ids
- allow converting a project back to private when only one manager/member
- add French and English translations for new action

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a965f13248323b4f42c7385609a31