### PR TITLE
Allow hex color values for lists

### DIFF
--- a/client/src/components/cards/Card/Card.jsx
+++ b/client/src/components/cards/Card/Card.jsx
@@ -90,14 +90,17 @@ const Card = React.memo(({ id, isInline }) => {
     }
   }
 
-  const colorLineNode = list.color && (
-    <div
-      className={classNames(
-        styles.colorLine,
-        globalStyles[`background${upperFirst(camelCase(list.color))}`],
-      )}
-    />
-  );
+  const colorLineNode =
+    list.color && (
+      <div
+        className={classNames(
+          styles.colorLine,
+          !list.color.startsWith('#') &&
+            globalStyles[`background${upperFirst(camelCase(list.color))}`],
+        )}
+        style={list.color.startsWith('#') ? { backgroundColor: list.color } : null}
+      />
+    );
 
   return (
     <div

--- a/client/src/components/lists/List/EditColorStep.jsx
+++ b/client/src/components/lists/List/EditColorStep.jsx
@@ -72,6 +72,18 @@ const EditColorStep = React.memo(({ listId, onBack, onClose }) => {
             />
           ))}
         </div>
+        <input
+          type="color"
+          className={styles.colorInput}
+          defaultValue={defaultValue && defaultValue.startsWith('#') ? defaultValue : '#000000'}
+          onChange={(e) =>
+            dispatch(
+              entryActions.updateList(listId, {
+                color: e.target.value,
+              }),
+            )
+          }
+        />
         {defaultValue && (
           <Button
             fluid

--- a/client/src/components/lists/List/EditColorStep.module.scss
+++ b/client/src/components/lists/List/EditColorStep.module.scss
@@ -57,4 +57,13 @@
       display: table;
     }
   }
+
+  .colorInput {
+    display: block;
+    margin-top: 12px;
+    width: 100%;
+    height: 32px;
+    padding: 0;
+    border: none;
+  }
 }

--- a/client/src/components/lists/List/List.jsx
+++ b/client/src/components/lists/List/List.jsx
@@ -177,8 +177,10 @@ const List = React.memo(({ id, index }) => {
                       name="circle"
                       className={classNames(
                         styles.headerNameColor,
-                        globalStyles[`color${upperFirst(camelCase(list.color))}`],
+                        !list.color.startsWith('#') &&
+                          globalStyles[`color${upperFirst(camelCase(list.color))}`],
                       )}
+                      style={list.color.startsWith('#') ? { color: list.color } : null}
                     />
                   )}
                   {list.name}

--- a/server/api/controllers/lists/update.js
+++ b/server/api/controllers/lists/update.js
@@ -5,6 +5,8 @@
 
 const { idInput } = require('../../../utils/inputs');
 
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+
 const Errors = {
   NOT_ENOUGH_RIGHTS: {
     notEnoughRights: 'Not enough rights',
@@ -35,7 +37,7 @@ module.exports = {
     },
     color: {
       type: 'string',
-      isIn: List.COLORS,
+      custom: (value) => HEX_COLOR_REGEX.test(value) || List.COLORS.includes(value),
       allowNull: true,
     },
   },

--- a/server/api/models/List.js
+++ b/server/api/models/List.js
@@ -44,6 +44,8 @@ const COLORS = [
   'turquoise-sea',
 ];
 
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+
 module.exports = {
   Types,
   SortFieldNames,
@@ -72,7 +74,7 @@ module.exports = {
     },
     color: {
       type: 'string',
-      isIn: COLORS,
+      custom: (value) => HEX_COLOR_REGEX.test(value) || COLORS.includes(value),
       allowNull: true,
     },
 

--- a/server/utils/validators.js
+++ b/server/utils/validators.js
@@ -12,6 +12,7 @@ const MAX_STRING_ID = '9223372036854775807';
 const ID_REGEX = /^[1-9][0-9]*$/;
 const IDS_WITH_COMMA_REGEX = /^[1-9][0-9]*(,[1-9][0-9]*)*$/;
 const USERNAME_REGEX = /^[a-zA-Z0-9]+((_|\.)?[a-zA-Z0-9])*$/;
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
 const isUrl = (value) =>
   validator.isURL(value, {
@@ -36,6 +37,8 @@ const isEmailOrUsername = (value) =>
     : value.length >= 3 && value.length <= 16 && USERNAME_REGEX.test(value);
 
 const isDueDate = (value) => moment(value, moment.ISO_8601, true).isValid();
+
+const isHexColor = (value) => HEX_COLOR_REGEX.test(value);
 
 const isStopwatch = (value) => {
   if (!_.isPlainObject(value) || _.size(value) !== 2) {
@@ -68,5 +71,6 @@ module.exports = {
   isPassword,
   isEmailOrUsername,
   isDueDate,
+  isHexColor,
   isStopwatch,
 };


### PR DESCRIPTION
## Summary
- let lists accept hex color strings in backend validation
- support custom hex colors in lists update API
- add color picker to list color editing UI
- render hex colors inline in list headers and cards

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9ee11a2483238847282c5a8d81dd