### PR TITLE
Add story points configuration for projects

### DIFF
--- a/client/src/components/projects/ProjectSettingsModal/GeneralPane/GeneralPane.jsx
+++ b/client/src/components/projects/ProjectSettingsModal/GeneralPane/GeneralPane.jsx
@@ -71,6 +71,25 @@ const GeneralPane = React.memo(() => {
         <>
           <Divider horizontal section>
             <Header as="h4">
+              {t('common.configuration', {
+                context: 'title',
+              })}
+            </Header>
+          </Divider>
+          <Radio
+            toggle
+            name="useStoryPoints"
+            checked={project.useStoryPoints}
+            label={t('common.useStoryPointsInProject')}
+            className={styles.radio}
+            onChange={handleToggleChange}
+          />
+        </>
+      )}
+      {canEdit && (
+        <>
+          <Divider horizontal section>
+            <Header as="h4">
               {t('common.dangerZone', {
                 context: 'title',
               })}

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -162,6 +162,8 @@ export default {
       description: 'Description',
       detectAutomatically: 'Detect automatically',
       display: 'Display',
+      configuration: 'Configuration',
+      useStoryPointsInProject: 'Use story points in project',
       dropFileToUpload: 'Drop file to upload',
       dueDate_title: 'Due Date',
       dynamicAndUnevenlySpacedLayout: 'Dynamic and unevenly spaced layout.',

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -171,6 +171,8 @@ export default {
       description: 'Description',
       detectAutomatically: 'Détecter automatiquement',
       display: 'Affichage',
+      configuration: 'Configuration',
+      useStoryPointsInProject: 'Utiliser les story points dans le projet',
       dropFileToUpload: 'Déposer le fichier à télécharger',
       dueDate_title: "Date d'échéance",
       dynamicAndUnevenlySpacedLayout: 'Mise en page dynamique et inégalement espacée.',

--- a/client/src/models/Project.js
+++ b/client/src/models/Project.js
@@ -19,6 +19,7 @@ export default class extends BaseModel {
     backgroundType: attr(),
     backgroundGradient: attr(),
     isHidden: attr(),
+    useStoryPoints: attr(),
     isFavorite: attr({
       getDefault: () => false,
     }),

--- a/server/api/controllers/projects/update.js
+++ b/server/api/controllers/projects/update.js
@@ -67,6 +67,9 @@ module.exports = {
       isIn: Project.BACKGROUND_GRADIENTS,
       allowNull: true,
     },
+    useStoryPoints: {
+      type: 'boolean',
+    },
     isHidden: {
       type: 'boolean',
     },
@@ -123,12 +126,12 @@ module.exports = {
           throw Errors.NOT_ENOUGH_RIGHTS;
         }
 
-        availableInputKeys.push('ownerProjectManagerId', 'isHidden');
+        availableInputKeys.push('ownerProjectManagerId', 'isHidden', 'useStoryPoints');
       }
     } else if (currentUser.role === User.Roles.ADMIN) {
-      availableInputKeys.push('ownerProjectManagerId', 'isHidden');
+      availableInputKeys.push('ownerProjectManagerId', 'isHidden', 'useStoryPoints');
     } else if (projectManager) {
-      availableInputKeys.push('isHidden');
+      availableInputKeys.push('isHidden', 'useStoryPoints');
     }
 
     if (projectManager) {
@@ -138,6 +141,7 @@ module.exports = {
         'description',
         'backgroundType',
         'backgroundGradient',
+        'useStoryPoints',
       );
     }
 
@@ -195,6 +199,7 @@ module.exports = {
       'backgroundType',
       'backgroundGradient',
       'isHidden',
+      'useStoryPoints',
       'isFavorite',
     ]);
 

--- a/server/api/models/Project.js
+++ b/server/api/models/Project.js
@@ -84,6 +84,11 @@ module.exports = {
       defaultsTo: false, // TODO: implement via normalizeValues?
       columnName: 'is_hidden',
     },
+    useStoryPoints: {
+      type: 'boolean',
+      defaultsTo: false,
+      columnName: 'use_story_points',
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/server/db/migrations/20250708120000_add_use_story_points_to_project.js
+++ b/server/db/migrations/20250708120000_add_use_story_points_to_project.js
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+exports.up = async (knex) => {
+  await knex.schema.table('project', (table) => {
+    table.boolean('use_story_points').notNullable().defaultTo(false);
+  });
+};
+
+exports.down = (knex) =>
+  knex.schema.table('project', (table) => {
+    table.dropColumn('use_story_points');
+  });


### PR DESCRIPTION
## Summary
- add `useStoryPoints` column via migration and model updates
- expose `useStoryPoints` field in project update API
- support editing story points setting in project settings modal
- add translations for new UI text in English and French

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b71da65108323a0f69c00dd1aa089