### PR TITLE
Add story points bubble to card view

### DIFF
--- a/client/src/components/cards/Card/ProjectContent.jsx
+++ b/client/src/components/cards/Card/ProjectContent.jsx
@@ -17,6 +17,7 @@ import { BoardMembershipRoles, BoardViews, ListTypes } from '../../../constants/
 import TaskList from './TaskList';
 import DueDateChip from '../DueDateChip';
 import StopwatchChip from '../StopwatchChip';
+import StoryPointsChip from '../StoryPointsChip';
 import UserAvatar from '../../users/UserAvatar';
 import LabelChip from '../../labels/LabelChip';
 import CustomFieldValueChip from '../../custom-field-values/CustomFieldValueChip';
@@ -54,6 +55,7 @@ const ProjectContent = React.memo(({ cardId }) => {
 
   const card = useSelector((state) => selectCardById(state, cardId));
   const list = useSelector((state) => selectListById(state, card.listId));
+  const project = useSelector(selectors.selectCurrentProject);
   const cardType = useSelector((state) => {
     if (!card.cardTypeId) {
       return null;
@@ -158,18 +160,23 @@ const ProjectContent = React.memo(({ cardId }) => {
 
   return (
     <div className={styles.wrapper}>
-      <div className={classNames(styles.name, isInClosedList && styles.nameClosed)}>
-        {(() => {
-          const iconName = (cardType && cardType.icon) || CardTypeIcons[card.type];
-          return iconName ? (
-            <Icon
-              name={iconName}
-              className={styles.typeIcon}
-              style={cardType && cardType.color ? { color: cardType.color } : undefined}
-            />
-          ) : null;
-        })()}
-        {card.name}
+      <div className={styles.nameRow}>
+        <div className={classNames(styles.name, isInClosedList && styles.nameClosed)}>
+          {(() => {
+            const iconName = (cardType && cardType.icon) || CardTypeIcons[card.type];
+            return iconName ? (
+              <Icon
+                name={iconName}
+                className={styles.typeIcon}
+                style={cardType && cardType.color ? { color: cardType.color } : undefined}
+              />
+            ) : null;
+          })()}
+          {card.name}
+        </div>
+        {project.useStoryPoints && card.storyPoints !== 0 && (
+          <StoryPointsChip value={card.storyPoints} size="tiny" className={styles.storyPoints} />
+        )}
       </div>
       {coverUrl && (
         <div className={styles.coverWrapper}>

--- a/client/src/components/cards/Card/ProjectContent.module.scss
+++ b/client/src/components/cards/Card/ProjectContent.module.scss
@@ -76,6 +76,17 @@
     display: block;
   }
 
+  .nameRow {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .storyPoints {
+    flex-shrink: 0;
+    margin-left: 4px;
+  }
+
   .name {
     color: #17394d;
     font-size: 14px;

--- a/client/src/components/cards/Card/StoryContent.jsx
+++ b/client/src/components/cards/Card/StoryContent.jsx
@@ -14,6 +14,7 @@ import markdownToText from '../../../utils/markdown-to-text';
 import { BoardViews, ListTypes } from '../../../constants/Enums';
 import LabelChip from '../../labels/LabelChip';
 import CustomFieldValueChip from '../../custom-field-values/CustomFieldValueChip';
+import StoryPointsChip from '../StoryPointsChip';
 
 import styles from './StoryContent.module.scss';
 
@@ -41,6 +42,7 @@ const StoryContent = React.memo(({ cardId }) => {
 
   const card = useSelector((state) => selectCardById(state, cardId));
   const list = useSelector((state) => selectListById(state, card.listId));
+  const project = useSelector(selectors.selectCurrentProject);
   const labelIds = useSelector((state) => selectLabelIdsByCardId(state, cardId));
   const attachmentsTotal = useSelector((state) => selectAttachmentsTotalByCardId(state, cardId));
 
@@ -107,8 +109,13 @@ const StoryContent = React.memo(({ cardId }) => {
             ))}
           </span>
         )}
-        <div className={classNames(styles.name, isInClosedList && styles.nameClosed)}>
-          {card.name}
+        <div className={styles.nameRow}>
+          <div className={classNames(styles.name, isInClosedList && styles.nameClosed)}>
+            {card.name}
+          </div>
+          {project.useStoryPoints && card.storyPoints !== 0 && (
+            <StoryPointsChip value={card.storyPoints} size="tiny" className={styles.storyPoints} />
+          )}
         </div>
         {card.description && <div className={styles.descriptionText}>{descriptionText}</div>}
         {(attachmentsTotal > 0 || notificationsTotal > 0 || listName) && (

--- a/client/src/components/cards/Card/StoryContent.module.scss
+++ b/client/src/components/cards/Card/StoryContent.module.scss
@@ -64,6 +64,12 @@
     overflow: hidden;
   }
 
+  .nameRow {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
   .name {
     color: #17394d;
     font-size: 16px;
@@ -76,6 +82,11 @@
 
   .nameClosed {
     text-decoration: line-through;
+  }
+
+  .storyPoints {
+    flex-shrink: 0;
+    margin-left: 4px;
   }
 
   .notification {

--- a/client/src/components/cards/StoryPointsChip/StoryPointsChip.jsx
+++ b/client/src/components/cards/StoryPointsChip/StoryPointsChip.jsx
@@ -1,0 +1,37 @@
+import upperFirst from 'lodash/upperFirst';
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import styles from './StoryPointsChip.module.scss';
+
+const Sizes = {
+  TINY: 'tiny',
+  SMALL: 'small',
+  MEDIUM: 'medium',
+};
+
+const StoryPointsChip = React.memo(({ value, size, className }) => (
+  <span
+    className={classNames(
+      styles.wrapper,
+      styles[`wrapper${upperFirst(size)}`],
+      className,
+    )}
+  >
+    {value}
+  </span>
+));
+
+StoryPointsChip.propTypes = {
+  value: PropTypes.number.isRequired,
+  size: PropTypes.oneOf(Object.values(Sizes)),
+  className: PropTypes.string,
+};
+
+StoryPointsChip.defaultProps = {
+  size: Sizes.MEDIUM,
+  className: undefined,
+};
+
+export default StoryPointsChip;

--- a/client/src/components/cards/StoryPointsChip/StoryPointsChip.jsx
+++ b/client/src/components/cards/StoryPointsChip/StoryPointsChip.jsx
@@ -12,13 +12,7 @@ const Sizes = {
 };
 
 const StoryPointsChip = React.memo(({ value, size, className }) => (
-  <span
-    className={classNames(
-      styles.wrapper,
-      styles[`wrapper${upperFirst(size)}`],
-      className,
-    )}
-  >
+  <span className={classNames(styles.wrapper, styles[`wrapper${upperFirst(size)}`], className)}>
     {value}
   </span>
 ));

--- a/client/src/components/cards/StoryPointsChip/StoryPointsChip.module.scss
+++ b/client/src/components/cards/StoryPointsChip/StoryPointsChip.module.scss
@@ -1,0 +1,29 @@
+:global(#app) {
+  .wrapper {
+    background: #dce0e4;
+    border-radius: 3px;
+    color: #6a808b;
+    display: inline-block;
+    font-variant-numeric: tabular-nums;
+    transition: background 0.3s ease;
+  }
+
+  /* Sizes */
+
+  .wrapperTiny {
+    font-size: 12px;
+    line-height: 20px;
+    padding: 0 6px;
+  }
+
+  .wrapperSmall {
+    font-size: 12px;
+    line-height: 20px;
+    padding: 2px 8px;
+  }
+
+  .wrapperMedium {
+    line-height: 20px;
+    padding: 6px 12px;
+  }
+}

--- a/client/src/components/cards/StoryPointsChip/StoryPointsChip.module.scss
+++ b/client/src/components/cards/StoryPointsChip/StoryPointsChip.module.scss
@@ -14,6 +14,7 @@
     font-size: 12px;
     line-height: 20px;
     padding: 0 6px;
+    margin-bottom: 8px;
   }
 
   .wrapperSmall {

--- a/client/src/components/cards/StoryPointsChip/index.js
+++ b/client/src/components/cards/StoryPointsChip/index.js
@@ -1,0 +1,3 @@
+import StoryPointsChip from './StoryPointsChip';
+
+export default StoryPointsChip;


### PR DESCRIPTION
## Summary
- display story points on cards when enabled
- support showing story points in story and project card views
- add StoryPointsChip component for small badge

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b84955534832380233756a1b4688e