### PR TITLE
Add story points totals in list headers

### DIFF
--- a/client/src/components/lists/List/List.jsx
+++ b/client/src/components/lists/List/List.jsx
@@ -26,6 +26,7 @@ import DraggableCard from '../../cards/DraggableCard';
 import AddCard from '../../cards/AddCard';
 import ArchiveCardsStep from '../../cards/ArchiveCardsStep';
 import PlusMathIcon from '../../../assets/images/plus-math-icon.svg?react';
+import StoryPointsChip from '../../cards/StoryPointsChip';
 
 import styles from './List.module.scss';
 import globalStyles from '../../../styles.module.scss';
@@ -38,9 +39,16 @@ const List = React.memo(({ id, index }) => {
     [],
   );
 
+  const selectStoryPointsTotalByListId = useMemo(
+    () => selectors.makeSelectStoryPointsTotalByListId(),
+    [],
+  );
+
   const isFavoritesActive = useSelector(selectors.selectIsFavoritesActiveForCurrentUser);
   const list = useSelector((state) => selectListById(state, id));
   const cardIds = useSelector((state) => selectFilteredCardIdsByListId(state, id));
+  const storyPointsTotal = useSelector((state) => selectStoryPointsTotalByListId(state, id));
+  const project = useSelector(selectors.selectCurrentProject);
 
   const { canEdit, canArchiveCards, canAddCard, canDropCard } = useSelector((state) => {
     const isEditModeEnabled = selectors.selectIsEditModeEnabled(state); // TODO: move out?
@@ -186,6 +194,13 @@ const List = React.memo(({ id, index }) => {
                   )}
                   {list.name}
                 </div>
+              )}
+              {project.useStoryPoints && storyPointsTotal !== 0 && (
+                <StoryPointsChip
+                  value={storyPointsTotal}
+                  size="tiny"
+                  className={styles.storyPoints}
+                />
               )}
               {list.type !== ListTypes.ACTIVE && (
                 <Icon

--- a/client/src/components/lists/List/List.module.scss
+++ b/client/src/components/lists/List/List.module.scss
@@ -133,8 +133,11 @@
 
   .storyPoints {
     position: absolute;
-    right: 44px;
-    top: 6px;
+    right: 14px;
+    top: 9px;
+    margin-bottom: 8px;
+    background-color: #FFF;
+    color: #333333;
   }
 
   .headerName {

--- a/client/src/components/lists/List/List.module.scss
+++ b/client/src/components/lists/List/List.module.scss
@@ -131,6 +131,12 @@
     top: 10px;
   }
 
+  .storyPoints {
+    position: absolute;
+    right: 44px;
+    top: 6px;
+  }
+
   .headerName {
     color: #17394d;
     font-weight: bold;

--- a/client/src/components/lists/List/List.module.scss
+++ b/client/src/components/lists/List/List.module.scss
@@ -140,6 +140,11 @@
     color: #333333;
   }
 
+  .storyPoints:has(+ i),
+  .storyPoints:has(+ button) {
+    right: 44px;
+  }
+
   .headerName {
     color: #17394d;
     font-weight: bold;

--- a/client/src/selectors/lists.js
+++ b/client/src/selectors/lists.js
@@ -64,6 +64,25 @@ export const makeSelectFilteredCardIdsByListId = () =>
 
 export const selectFilteredCardIdsByListId = makeSelectFilteredCardIdsByListId();
 
+export const makeSelectStoryPointsTotalByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    ({ List }, id) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      return listModel
+        .getFilteredCardsModelArray()
+        .reduce((total, cardModel) => total + cardModel.storyPoints, 0);
+    },
+  );
+
+export const selectStoryPointsTotalByListId = makeSelectStoryPointsTotalByListId();
+
 export const selectCurrentListId = createSelector(
   orm,
   (state) => selectPath(state).boardId,
@@ -154,6 +173,8 @@ export default {
   selectCardIdsByListId,
   makeSelectFilteredCardIdsByListId,
   selectFilteredCardIdsByListId,
+  makeSelectStoryPointsTotalByListId,
+  selectStoryPointsTotalByListId,
   selectCurrentListId,
   selectCurrentList,
   selectFirstFiniteListId,


### PR DESCRIPTION
## Summary
- compute story point totals per list
- display story points bubble in list headers using StoryPointsChip

## Testing
- `npm run lint` in `client`
- `npm test` in `client`
- `npm run lint` in `server`
- `npm test` in `server` *(fails: hook `userconfig` failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_686b887de7908323946e250ddcb72295