### PR TITLE
Fix linked tasks styling

### DIFF
--- a/client/src/components/cards/Card/TaskList/Task.jsx
+++ b/client/src/components/cards/Card/TaskList/Task.jsx
@@ -9,17 +9,42 @@ import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 
 import selectors from '../../../../selectors';
+import { ListTypes } from '../../../../constants/Enums';
 import Linkify from '../../../common/Linkify';
 
 import styles from './Task.module.scss';
 
 const Task = React.memo(({ id }) => {
   const selectTaskById = useMemo(() => selectors.makeSelectTaskById(), []);
+  const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
+  const selectListById = useMemo(() => selectors.makeSelectListById(), []);
 
   const task = useSelector((state) => selectTaskById(state, id));
 
+  const isLinkedCardCompleted = useSelector((state) => {
+    const regex = /\/cards\/([^/]+)/g;
+    const matches = task.name.matchAll(regex);
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [, cardId] of matches) {
+      const card = selectCardById(state, cardId);
+
+      if (card) {
+        const list = selectListById(state, card.listId);
+
+        if (list && list.type === ListTypes.CLOSED) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  });
+
+  const isCompleted = task.isCompleted || isLinkedCardCompleted;
+
   return (
-    <li className={classNames(styles.wrapper, task.isCompleted && styles.wrapperCompleted)}>
+    <li className={classNames(styles.wrapper, isCompleted && styles.wrapperCompleted)}>
       <Linkify linkStopPropagation>{task.name}</Linkify>
     </li>
   );


### PR DESCRIPTION
## Summary
- mark linked card tasks as completed when their cards are closed

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9abb7e9083238d927de5cc3a02fb