### PR TITLE
Add Scrum feature

### DIFF
--- a/client/src/components/projects/AddProjectModal/AddProjectModal.jsx
+++ b/client/src/components/projects/AddProjectModal/AddProjectModal.jsx
@@ -146,9 +146,7 @@ const AddProjectModal = React.memo(() => {
               { value: ProjectTemplates.KABAN, text: t('common.kabanProject') },
             ]}
             className={styles.field}
-            onChange={(_, { value }) =>
-              handleFieldChange(null, { name: 'template', value })
-            }
+            onChange={(_, { value }) => handleFieldChange(null, { name: 'template', value })}
           />
           <Button
             inverted

--- a/client/src/components/projects/ProjectSettingsModal/GeneralPane/GeneralPane.jsx
+++ b/client/src/components/projects/ProjectSettingsModal/GeneralPane/GeneralPane.jsx
@@ -39,6 +39,24 @@ const GeneralPane = React.memo(() => {
     [dispatch],
   );
 
+  const handleScrumToggleChange = useCallback(
+    (_, { checked }) => {
+      if (!checked) {
+        // eslint-disable-next-line no-alert
+        if (!window.confirm(t('common.areYouSureYouWantToDisableScrum'))) {
+          return;
+        }
+      }
+
+      dispatch(
+        entryActions.updateCurrentProject({
+          useScrum: checked,
+        }),
+      );
+    },
+    [dispatch, t],
+  );
+
   const handleDeleteConfirm = useCallback(() => {
     dispatch(entryActions.deleteCurrentProject());
   }, [dispatch]);
@@ -83,6 +101,14 @@ const GeneralPane = React.memo(() => {
             label={t('common.useStoryPointsInProject')}
             className={styles.radio}
             onChange={handleToggleChange}
+          />
+          <Radio
+            toggle
+            name="useScrum"
+            checked={project.useScrum}
+            label={t('common.useScrum')}
+            className={styles.radio}
+            onChange={handleScrumToggleChange}
           />
         </>
       )}

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -74,6 +74,8 @@ export default {
         'Are you sure you want to make this project shared?',
       areYouSureYouWantToMakeThisProjectPrivate:
         'Are you sure you want to make this project private?',
+      areYouSureYouWantToDisableScrum:
+        'Disabling scrum will delete the "Backlog" and "Sprint" boards and their content. Are you sure?',
       areYouSureYouWantToRemoveThisManagerFromProject:
         'Are you sure you want to remove this manager from the project?',
       areYouSureYouWantToRemoveThisMemberFromBoard:
@@ -164,6 +166,7 @@ export default {
       display: 'Display',
       configuration: 'Configuration',
       useStoryPointsInProject: 'Use story points in project',
+      useScrum: 'Use scrum',
       dropFileToUpload: 'Drop file to upload',
       dueDate_title: 'Due Date',
       dynamicAndUnevenlySpacedLayout: 'Dynamic and unevenly spaced layout.',

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -83,7 +83,7 @@ export default {
       areYouSureYouWantToMakeThisProjectPrivate:
         'Êtes-vous sûr de vouloir transformer ce projet en projet privé ?',
       areYouSureYouWantToDisableScrum:
-        "La désactivation de Scrum supprimera les tableaux \"Backlog\" et \"Sprint\" ainsi que leur contenu. Êtes-vous sûr ?",
+        'La désactivation de Scrum supprimera les tableaux "Backlog" et "Sprint" ainsi que leur contenu. Êtes-vous sûr ?',
       areYouSureYouWantToRemoveThisManagerFromProject:
         'Êtes-vous sûr de vouloir supprimer ce responsable du projet ?',
       areYouSureYouWantToRemoveThisMemberFromBoard:

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -82,6 +82,8 @@ export default {
         "Etes-vous sûr de vouloir transformer ce projet en projet d'équipe ?",
       areYouSureYouWantToMakeThisProjectPrivate:
         'Êtes-vous sûr de vouloir transformer ce projet en projet privé ?',
+      areYouSureYouWantToDisableScrum:
+        "La désactivation de Scrum supprimera les tableaux \"Backlog\" et \"Sprint\" ainsi que leur contenu. Êtes-vous sûr ?",
       areYouSureYouWantToRemoveThisManagerFromProject:
         'Êtes-vous sûr de vouloir supprimer ce responsable du projet ?',
       areYouSureYouWantToRemoveThisMemberFromBoard:
@@ -174,6 +176,7 @@ export default {
       display: 'Affichage',
       configuration: 'Configuration',
       useStoryPointsInProject: 'Utiliser les story points dans le projet',
+      useScrum: 'Utiliser Scrum',
       dropFileToUpload: 'Déposer le fichier à télécharger',
       dueDate_title: "Date d'échéance",
       dynamicAndUnevenlySpacedLayout: 'Mise en page dynamique et inégalement espacée.',

--- a/client/src/models/Project.js
+++ b/client/src/models/Project.js
@@ -20,6 +20,7 @@ export default class extends BaseModel {
     backgroundGradient: attr(),
     isHidden: attr(),
     useStoryPoints: attr(),
+    useScrum: attr(),
     isFavorite: attr({
       getDefault: () => false,
     }),

--- a/server/api/controllers/projects/create.js
+++ b/server/api/controllers/projects/create.js
@@ -1,10 +1,9 @@
 /*!
  * Copyright (c) 2024 PLANKA Software GmbH
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
-*/
+ */
 
 const { POSITION_GAP } = require('../../../constants');
-
 
 module.exports = {
   inputs: {
@@ -34,9 +33,7 @@ module.exports = {
   async fn(inputs) {
     const { currentUser } = this.req;
 
-    const t = sails.helpers.utils.makeTranslator(
-      currentUser.language || this.req.getLocale(),
-    );
+    const t = sails.helpers.utils.makeTranslator(currentUser.language || this.req.getLocale());
 
     const values = _.pick(inputs, ['type', 'name', 'description']);
 

--- a/server/api/controllers/projects/update.js
+++ b/server/api/controllers/projects/update.js
@@ -113,31 +113,11 @@ module.exports = {
 
     let project = await Project.qm.getOneById(inputs.id);
 
-    const prevUseScrum = project ? project.useScrum : false;
-
     if (!project) {
       throw Errors.PROJECT_NOT_FOUND;
     }
 
-    if (!prevUseScrum && project.useScrum) {
-      await sails.helpers.projects.deleteScrumBoards.with({
-        project,
-        actorUser: currentUser,
-        request: this.req,
-      });
-
-      await sails.helpers.projects.createScrumBoards.with({
-        project,
-        actorUser: currentUser,
-        request: this.req,
-      });
-    } else if (prevUseScrum && !project.useScrum) {
-      await sails.helpers.projects.deleteScrumBoards.with({
-        project,
-        actorUser: currentUser,
-        request: this.req,
-      });
-    }
+    const prevUseScrum = project.useScrum;
 
     const projectManager = await ProjectManager.qm.getOneByProjectIdAndUserId(
       project.id,
@@ -260,6 +240,26 @@ module.exports = {
 
     if (!project) {
       throw Errors.PROJECT_NOT_FOUND;
+    }
+
+    if (!prevUseScrum && project.useScrum) {
+      await sails.helpers.projects.deleteScrumBoards.with({
+        project,
+        actorUser: currentUser,
+        request: this.req,
+      });
+
+      await sails.helpers.projects.createScrumBoards.with({
+        project,
+        actorUser: currentUser,
+        request: this.req,
+      });
+    } else if (prevUseScrum && !project.useScrum) {
+      await sails.helpers.projects.deleteScrumBoards.with({
+        project,
+        actorUser: currentUser,
+        request: this.req,
+      });
     }
 
     return {

--- a/server/api/helpers/projects/create-scrum-boards.js
+++ b/server/api/helpers/projects/create-scrum-boards.js
@@ -1,4 +1,4 @@
-const { POSITION_GAP } = require('../../constants');
+const { POSITION_GAP } = require('../../../constants');
 
 module.exports = {
   inputs: {
@@ -18,28 +18,48 @@ module.exports = {
     });
 
     await sails.helpers.lists.createOne.with({
-      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP, name: 'Raw Ideas' },
+      values: {
+        board: backlog,
+        type: List.Types.ACTIVE,
+        position: POSITION_GAP,
+        name: 'Raw Ideas',
+      },
       project,
       actorUser,
       request,
     });
 
     await sails.helpers.lists.createOne.with({
-      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP * 2, name: 'To Refine' },
+      values: {
+        board: backlog,
+        type: List.Types.ACTIVE,
+        position: POSITION_GAP * 2,
+        name: 'To Refine',
+      },
       project,
       actorUser,
       request,
     });
 
     await sails.helpers.lists.createOne.with({
-      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP * 3, name: 'To Estimate' },
+      values: {
+        board: backlog,
+        type: List.Types.ACTIVE,
+        position: POSITION_GAP * 3,
+        name: 'To Estimate',
+      },
       project,
       actorUser,
       request,
     });
 
     await sails.helpers.lists.createOne.with({
-      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP * 4, name: 'Ready for Sprint' },
+      values: {
+        board: backlog,
+        type: List.Types.ACTIVE,
+        position: POSITION_GAP * 4,
+        name: 'Ready for Sprint',
+      },
       project,
       actorUser,
       request,
@@ -59,21 +79,36 @@ module.exports = {
     });
 
     await sails.helpers.lists.createOne.with({
-      values: { board: sprint, type: List.Types.ACTIVE, position: POSITION_GAP * 2, name: 'In Progress' },
+      values: {
+        board: sprint,
+        type: List.Types.ACTIVE,
+        position: POSITION_GAP * 2,
+        name: 'In Progress',
+      },
       project,
       actorUser,
       request,
     });
 
     await sails.helpers.lists.createOne.with({
-      values: { board: sprint, type: List.Types.ACTIVE, position: POSITION_GAP * 3, name: 'Code Review' },
+      values: {
+        board: sprint,
+        type: List.Types.ACTIVE,
+        position: POSITION_GAP * 3,
+        name: 'Code Review',
+      },
       project,
       actorUser,
       request,
     });
 
     await sails.helpers.lists.createOne.with({
-      values: { board: sprint, type: List.Types.ACTIVE, position: POSITION_GAP * 4, name: 'Testing' },
+      values: {
+        board: sprint,
+        type: List.Types.ACTIVE,
+        position: POSITION_GAP * 4,
+        name: 'Testing',
+      },
       project,
       actorUser,
       request,

--- a/server/api/helpers/projects/create-scrum-boards.js
+++ b/server/api/helpers/projects/create-scrum-boards.js
@@ -1,0 +1,89 @@
+const { POSITION_GAP } = require('../../constants');
+
+module.exports = {
+  inputs: {
+    project: { type: 'ref', required: true },
+    actorUser: { type: 'ref', required: true },
+    request: { type: 'ref' },
+  },
+
+  async fn({ project, actorUser, request }) {
+    const boards = await Board.qm.getByProjectId(project.id);
+    const startPos = POSITION_GAP * (boards.length + 1);
+
+    const { board: backlog } = await sails.helpers.boards.createOne.with({
+      values: { project, position: startPos, name: 'Backlog' },
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP, name: 'Raw Ideas' },
+      project,
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP * 2, name: 'To Refine' },
+      project,
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP * 3, name: 'To Estimate' },
+      project,
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: backlog, type: List.Types.ACTIVE, position: POSITION_GAP * 4, name: 'Ready for Sprint' },
+      project,
+      actorUser,
+      request,
+    });
+
+    const { board: sprint } = await sails.helpers.boards.createOne.with({
+      values: { project, position: startPos + POSITION_GAP, name: 'Sprint' },
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: sprint, type: List.Types.ACTIVE, position: POSITION_GAP, name: 'To Do' },
+      project,
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: sprint, type: List.Types.ACTIVE, position: POSITION_GAP * 2, name: 'In Progress' },
+      project,
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: sprint, type: List.Types.ACTIVE, position: POSITION_GAP * 3, name: 'Code Review' },
+      project,
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: sprint, type: List.Types.ACTIVE, position: POSITION_GAP * 4, name: 'Testing' },
+      project,
+      actorUser,
+      request,
+    });
+
+    await sails.helpers.lists.createOne.with({
+      values: { board: sprint, type: List.Types.CLOSED, position: POSITION_GAP * 5, name: 'Done' },
+      project,
+      actorUser,
+      request,
+    });
+  },
+};

--- a/server/api/helpers/projects/delete-scrum-boards.js
+++ b/server/api/helpers/projects/delete-scrum-boards.js
@@ -1,0 +1,23 @@
+module.exports = {
+  inputs: {
+    project: { type: 'ref', required: true },
+    actorUser: { type: 'ref', required: true },
+    request: { type: 'ref' },
+  },
+
+  async fn({ project, actorUser, request }) {
+    const boards = await Board.qm.getByProjectId(project.id);
+    const scrumBoards = boards.filter((b) => ['Backlog', 'Sprint'].includes(b.name));
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const board of scrumBoards) {
+      // eslint-disable-next-line no-await-in-loop
+      await sails.helpers.boards.deleteOne.with({
+        record: board,
+        project,
+        actorUser,
+        request,
+      });
+    }
+  },
+};

--- a/server/api/models/Project.js
+++ b/server/api/models/Project.js
@@ -89,6 +89,11 @@ module.exports = {
       defaultsTo: false,
       columnName: 'use_story_points',
     },
+    useScrum: {
+      type: 'boolean',
+      defaultsTo: false,
+      columnName: 'use_scrum',
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/server/db/migrations/20250715120000_add_use_scrum_to_project.js
+++ b/server/db/migrations/20250715120000_add_use_scrum_to_project.js
@@ -1,0 +1,10 @@
+exports.up = async (knex) => {
+  await knex.schema.table('project', (table) => {
+    table.boolean('use_scrum').notNullable().defaultTo(false);
+  });
+};
+
+exports.down = (knex) =>
+  knex.schema.table('project', (table) => {
+    table.dropColumn('use_scrum');
+  });


### PR DESCRIPTION
## Summary
- add migrations and model field for scrum setting
- provide helpers to manage scrum boards
- toggle scrum setting from UI with confirmation
- localize new strings

## Testing
- `npm test` *(fails: mocha not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686c0568d69c8323b2a83ff1cbf2036b