### PR TITLE
Restrict renaming/deleting Scrum boards

### DIFF
--- a/client/src/components/boards/BoardSettingsModal/GeneralPane/EditInformation.jsx
+++ b/client/src/components/boards/BoardSettingsModal/GeneralPane/EditInformation.jsx
@@ -20,6 +20,12 @@ const EditInformation = React.memo(() => {
 
   const boardId = useSelector((state) => selectors.selectCurrentModal(state).params.id);
   const board = useSelector((state) => selectBoardById(state, boardId));
+  const project = useSelector((state) =>
+    board ? selectors.selectProjectById(state, board.projectId) : null,
+  );
+
+  const isScrumBoard =
+    board && project && project.useScrum && ['Backlog', 'Sprint'].includes(board.name);
 
   const dispatch = useDispatch();
   const [t] = useTranslation();
@@ -66,8 +72,13 @@ const EditInformation = React.memo(() => {
         maxLength={128}
         className={styles.field}
         onChange={handleFieldChange}
+        disabled={isScrumBoard}
       />
-      <Button positive disabled={dequal(cleanData, defaultData)} content={t('action.save')} />
+      <Button
+        positive
+        disabled={dequal(cleanData, defaultData) || isScrumBoard}
+        content={t('action.save')}
+      />
     </Form>
   );
 });

--- a/client/src/components/boards/BoardSettingsModal/GeneralPane/GeneralPane.jsx
+++ b/client/src/components/boards/BoardSettingsModal/GeneralPane/GeneralPane.jsx
@@ -21,6 +21,12 @@ const GeneralPane = React.memo(() => {
 
   const boardId = useSelector((state) => selectors.selectCurrentModal(state).params.id);
   const board = useSelector((state) => selectBoardById(state, boardId));
+  const project = useSelector((state) =>
+    board ? selectors.selectProjectById(state, board.projectId) : null,
+  );
+
+  const isScrumBoard =
+    board && project && project.useScrum && ['Backlog', 'Sprint'].includes(board.name);
 
   const dispatch = useDispatch();
   const [t] = useTranslation();
@@ -34,29 +40,33 @@ const GeneralPane = React.memo(() => {
   return (
     <Tab.Pane attached={false} className={styles.wrapper}>
       <EditInformation />
-      <Divider horizontal section>
-        <Header as="h4">
-          {t('common.dangerZone', {
-            context: 'title',
-          })}
-        </Header>
-      </Divider>
-      <div className={styles.action}>
-        <ConfirmationPopup
-          title="common.deleteBoard"
-          content="common.areYouSureYouWantToDeleteThisBoard"
-          buttonContent="action.deleteBoard"
-          typeValue={board.name}
-          typeContent="common.typeTitleToConfirm"
-          onConfirm={handleDeleteConfirm}
-        >
-          <Button className={styles.actionButton}>
-            {t(`action.deleteBoard`, {
-              context: 'title',
-            })}
-          </Button>
-        </ConfirmationPopup>
-      </div>
+      {!isScrumBoard && (
+        <>
+          <Divider horizontal section>
+            <Header as="h4">
+              {t('common.dangerZone', {
+                context: 'title',
+              })}
+            </Header>
+          </Divider>
+          <div className={styles.action}>
+            <ConfirmationPopup
+              title="common.deleteBoard"
+              content="common.areYouSureYouWantToDeleteThisBoard"
+              buttonContent="action.deleteBoard"
+              typeValue={board.name}
+              typeContent="common.typeTitleToConfirm"
+              onConfirm={handleDeleteConfirm}
+            >
+              <Button className={styles.actionButton}>
+                {t(`action.deleteBoard`, {
+                  context: 'title',
+                })}
+              </Button>
+            </ConfirmationPopup>
+          </div>
+        </>
+      )}
     </Tab.Pane>
   );
 });


### PR DESCRIPTION
## Summary
- disable board name editing when project uses Scrum and board is `Backlog` or `Sprint`
- hide delete board option for Scrum boards

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run server:lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_686c136d89808323a7276b699a7c8aed