### PR TITLE
Add Scrum project template

### DIFF
--- a/client/src/components/projects/AddProjectModal/AddProjectModal.jsx
+++ b/client/src/components/projects/AddProjectModal/AddProjectModal.jsx
@@ -144,6 +144,7 @@ const AddProjectModal = React.memo(() => {
             options={[
               { value: ProjectTemplates.NONE, text: t('common.noTemplate') },
               { value: ProjectTemplates.KABAN, text: t('common.kabanProject') },
+              { value: ProjectTemplates.SCRUM, text: t('common.scrumProject') },
             ]}
             className={styles.field}
             onChange={(_, { value }) => handleFieldChange(null, { name: 'template', value })}

--- a/client/src/constants/Enums.js
+++ b/client/src/constants/Enums.js
@@ -45,6 +45,7 @@ export const ProjectTypes = {
 export const ProjectTemplates = {
   NONE: 'none',
   KABAN: 'kaban',
+  SCRUM: 'scrum',
 };
 
 export const ProjectBackgroundTypes = {

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -256,6 +256,7 @@ export default {
       projectTemplate: 'Project template',
       noTemplate: 'No template',
       kabanProject: 'Kaban Project',
+      scrumProject: 'Scrum Project',
       referenceDataAndKnowledgeStorage: 'Reference data and knowledge storage.',
       removeManager_title: 'Remove Manager',
       removeMember_title: 'Remove Member',

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -266,6 +266,7 @@ export default {
       projectTemplate: 'Modèle de projet',
       noTemplate: 'Aucun modèle',
       kabanProject: 'Projet Kaban',
+      scrumProject: 'Projet Scrum',
       referenceDataAndKnowledgeStorage: 'Stockage de données de référence et de connaissances.',
       removeManager_title: 'Supprimer le responsable',
       removeMember_title: 'Supprimer le membre',

--- a/client/src/sagas/core/services/projects.js
+++ b/client/src/sagas/core/services/projects.js
@@ -55,7 +55,7 @@ export function* createProject(data) {
 
   yield put(actions.createProject.success(project, projectManagers));
 
-  if (data.template === ProjectTemplates.KABAN) {
+  if (data.template === ProjectTemplates.KABAN || data.template === ProjectTemplates.SCRUM) {
     let projectFull;
     let included;
     try {

--- a/server/api/controllers/projects/create.js
+++ b/server/api/controllers/projects/create.js
@@ -25,7 +25,7 @@ module.exports = {
     },
     template: {
       type: 'string',
-      isIn: ['none', 'kaban'],
+      isIn: ['none', 'kaban', 'scrum'],
       defaultsTo: 'none',
     },
   },
@@ -36,6 +36,10 @@ module.exports = {
     const t = sails.helpers.utils.makeTranslator(currentUser.language || this.req.getLocale());
 
     const values = _.pick(inputs, ['type', 'name', 'description']);
+    if (inputs.template === 'scrum') {
+      values.useStoryPoints = true;
+      values.useScrum = true;
+    }
 
     const { project, projectManager } = await sails.helpers.projects.createOne.with({
       values,
@@ -85,6 +89,12 @@ module.exports = {
           position: POSITION_GAP * 3,
           name: t('Done'),
         },
+        project,
+        actorUser: currentUser,
+        request: this.req,
+      });
+    } else if (inputs.template === 'scrum') {
+      await sails.helpers.projects.createScrumBoards.with({
         project,
         actorUser: currentUser,
         request: this.req,


### PR DESCRIPTION
## Summary
- add new `SCRUM` entry in project templates enum
- allow selection of Scrum project template in the UI
- translate "Scrum Project" in English and French
- fetch project after creation when Scrum template is used
- server side: accept `scrum` template, enable story points and Scrum boards automatically

## Testing
- `npm test` *(fails: `mocha` not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c1869ee988323bd51888314513cc7