### PR TITLE
Add stable slug field to lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **Flexible Notifications**: Get alerts through 100+ providers, fully customizable to your workflow
 - **Seamless Authentication**: Single sign-on with OpenID Connect integration
 - **Multilingual & Easy to Translate**: Full internationalization support for a global audience
+- **Stable List Slugs**: Lists have optional `slug` identifiers for reliable API queries, unaffected by renaming
 
 ## How to Deploy
 

--- a/server/api/controllers/lists/update.js
+++ b/server/api/controllers/lists/update.js
@@ -41,6 +41,10 @@ module.exports = {
       custom: (value) => HEX_COLOR_REGEX.test(value) || List.COLORS.includes(value),
       allowNull: true,
     },
+    slug: {
+      type: 'string',
+      allowNull: true,
+    },
     defaultCardTypeId: {
       type: 'string',
       allowNull: true,

--- a/server/api/helpers/projects/create-scrum-boards.js
+++ b/server/api/helpers/projects/create-scrum-boards.js
@@ -8,9 +8,7 @@ module.exports = {
   },
 
   async fn({ project, actorUser, request }) {
-    const t = sails.helpers.utils.makeTranslator(
-      actorUser.language || request.getLocale(),
-    );
+    const t = sails.helpers.utils.makeTranslator(actorUser.language || request.getLocale());
     const boards = await Board.qm.getByProjectId(project.id);
     const startPos = POSITION_GAP * (boards.length + 1);
 
@@ -62,6 +60,7 @@ module.exports = {
         type: List.Types.ACTIVE,
         position: POSITION_GAP * 4,
         name: t('Ready for Sprint'),
+        slug: 'ready-for-sprint',
       },
       project,
       actorUser,
@@ -80,6 +79,7 @@ module.exports = {
         type: List.Types.ACTIVE,
         position: POSITION_GAP,
         name: t('To Do'),
+        slug: 'sprint-todo',
       },
       project,
       actorUser,

--- a/server/api/hooks/query-methods/models/List.js
+++ b/server/api/hooks/query-methods/models/List.js
@@ -41,6 +41,12 @@ const getOneById = (id, { boardId } = {}) => {
   return List.findOne(criteria);
 };
 
+const getOneByBoardIdAndSlug = (boardId, slug) =>
+  List.findOne({
+    boardId,
+    slug,
+  });
+
 const getOneTrashByBoardId = (boardId) =>
   List.findOne({
     boardId,
@@ -59,6 +65,7 @@ module.exports = {
   getByIds,
   getByBoardId,
   getOneById,
+  getOneByBoardIdAndSlug,
   getOneTrashByBoardId,
   updateOne,
   deleteOne,

--- a/server/api/models/List.js
+++ b/server/api/models/List.js
@@ -74,6 +74,10 @@ module.exports = {
       isNotEmptyString: true,
       allowNull: true,
     },
+    slug: {
+      type: 'string',
+      allowNull: true,
+    },
     defaultCardType: {
       type: 'string',
       defaultsTo: Card.Types.PROJECT,

--- a/server/db/migrations/20250722120000_add_slug_to_list.js
+++ b/server/db/migrations/20250722120000_add_slug_to_list.js
@@ -1,0 +1,19 @@
+exports.up = async (knex) => {
+  await knex.schema.table('list', (table) => {
+    table.text('slug');
+  });
+
+  await knex.schema.alterTable('list', (table) => {
+    table.unique(['board_id', 'slug']);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('list', (table) => {
+    table.dropUnique(['board_id', 'slug']);
+  });
+
+  await knex.schema.table('list', (table) => {
+    table.dropColumn('slug');
+  });
+};


### PR DESCRIPTION
## Summary
- add `slug` column to lists via migration
- expose `slug` attribute on the List model
- keep slug unchanged on list rename
- create scrum board lists with predefined slugs
- document list slugs in README

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run server:lint`
- `npm test` *(fails: hook `userconfig` failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_686c24ca0b2c832399b219ab843f6a0f