### PR TITLE
Enable moving cards between any lists

### DIFF
--- a/server/api/controllers/lists/move-cards.js
+++ b/server/api/controllers/lists/move-cards.js
@@ -51,11 +51,6 @@ module.exports = {
       throw Errors.LIST_NOT_FOUND; // Forbidden
     }
 
-    // TODO: allow for other types?
-    if (list.type !== List.Types.CLOSED) {
-      throw Errors.NOT_ENOUGH_RIGHTS;
-    }
-
     if (boardMembership.role !== BoardMembership.Roles.EDITOR) {
       throw Errors.NOT_ENOUGH_RIGHTS;
     }
@@ -68,11 +63,6 @@ module.exports = {
       throw Errors.LIST_NOT_FOUND; // Forbidden
     }
 
-    // TODO: allow for other types?
-    if (nextList.type !== List.Types.ARCHIVE) {
-      throw Errors.LIST_NOT_FOUND;
-    }
-
     const { cards, actions } = await sails.helpers.lists.moveCards.with({
       project,
       board,
@@ -80,6 +70,7 @@ module.exports = {
       values: {
         list: nextList,
       },
+      allowFiniteList: sails.helpers.lists.isFinite(nextList),
       actorUser: currentUser,
       request: this.req,
     });

--- a/server/api/helpers/lists/move-cards.js
+++ b/server/api/helpers/lists/move-cards.js
@@ -28,6 +28,10 @@ module.exports = {
     request: {
       type: 'ref',
     },
+    allowFiniteList: {
+      type: 'boolean',
+      defaultsTo: false,
+    },
   },
 
   exits: {
@@ -38,8 +42,7 @@ module.exports = {
   async fn(inputs) {
     const { values } = inputs;
 
-    // TODO: allow for finite lists?
-    if (sails.helpers.lists.isFinite(values.list)) {
+    if (!inputs.allowFiniteList && sails.helpers.lists.isFinite(values.list)) {
       throw 'listInValuesMustBeEndless';
     }
 

--- a/server/test/integration/helpers/move-cards.test.js
+++ b/server/test/integration/helpers/move-cards.test.js
@@ -1,0 +1,91 @@
+const { expect } = require('chai');
+
+// This test covers moving cards between active lists
+
+describe('helpers/lists.moveCards', () => {
+  let user;
+  let project;
+  let board;
+  let listA;
+  let listB;
+  let card1;
+  let card2;
+
+  before(async () => {
+    user = await User.qm.createOne({
+      email: 'move-cards@test.test',
+      password: 'test',
+      role: User.Roles.ADMIN,
+      name: 'tester',
+    });
+
+    project = await Project.qm.createOne({
+      name: 'Move Cards Project',
+      type: Project.Types.SHARED,
+    });
+
+    board = await Board.qm.createOne({
+      projectId: project.id,
+      name: 'Board',
+      position: 1,
+    });
+
+    await BoardMembership.qm.createOne({
+      projectId: project.id,
+      boardId: board.id,
+      userId: user.id,
+      role: BoardMembership.Roles.EDITOR,
+    });
+
+    listA = await List.qm.createOne({
+      boardId: board.id,
+      type: List.Types.ACTIVE,
+      position: 1,
+      name: 'List A',
+    });
+
+    listB = await List.qm.createOne({
+      boardId: board.id,
+      type: List.Types.ACTIVE,
+      position: 2,
+      name: 'List B',
+    });
+
+    card1 = await Card.qm.createOne({
+      boardId: board.id,
+      listId: listA.id,
+      name: 'Card 1',
+      type: Card.Types.PROJECT,
+    });
+
+    card2 = await Card.qm.createOne({
+      boardId: board.id,
+      listId: listA.id,
+      name: 'Card 2',
+      type: Card.Types.PROJECT,
+    });
+  });
+
+  it('moves cards and creates actions', async () => {
+    const { cards, actions } = await sails.helpers.lists.moveCards.with({
+      project,
+      board,
+      record: listA,
+      values: { list: listB },
+      actorUser: user,
+      allowFiniteList: true,
+    });
+
+    expect(cards).to.have.lengthOf(2);
+    cards.forEach((card) => {
+      expect(card.listId).to.equal(listB.id);
+    });
+
+    expect(actions).to.have.lengthOf(2);
+    actions.forEach((action) => {
+      expect(action.type).to.equal(Action.Types.MOVE_CARD);
+      expect(action.data.fromList.id).to.equal(listA.id);
+      expect(action.data.toList.id).to.equal(listB.id);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- relax list restrictions in `move-cards` controller
- allow finite lists as move targets in helper when flagged
- add integration test for moving cards between active lists

## Testing
- `npm run server:lint` *(fails: ESLint couldn't find configuration)*
- `npm run client:lint` *(fails: ESLint couldn't find configuration)*
- `npm run client:test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c321bcab08323aa5688a27df2b992