### PR TITLE
Set sprint start and end dates by default

### DIFF
--- a/client/src/components/lists/List/StartSprintStep.jsx
+++ b/client/src/components/lists/List/StartSprintStep.jsx
@@ -21,12 +21,20 @@ const StartSprintStep = React.memo(({ onClose }) => {
   const dispatch = useDispatch();
   const [t] = useTranslation();
 
-  const [data, handleFieldChange] = useForm({
-    startDate: '',
-    endDate: '',
-  });
-
   const project = useSelector(selectors.selectCurrentProject);
+
+  const [data, handleFieldChange] = useForm(() => {
+    const start = new Date();
+    const startDate = start.toISOString().slice(0, 10);
+
+    const end = new Date(start);
+    if (project && project.sprintDuration) {
+      end.setDate(end.getDate() + project.sprintDuration * 7);
+    }
+    const endDate = end.toISOString().slice(0, 10);
+
+    return { startDate, endDate };
+  });
 
   const selectListIdBySlug = useMemo(() => selectors.makeSelectListIdBySlug(), []);
   const readyListId = useSelector((state) => selectListIdBySlug(state, 'ready-for-sprint'));


### PR DESCRIPTION
## Summary
- use today's date as the default sprint start date
- calculate sprint end date from the start date and project sprint duration

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686ccf88ad908323a7750d198b96fae6