### PR TITLE
Add closed_at to cards

### DIFF
--- a/server/api/helpers/cards/create-one.js
+++ b/server/api/helpers/cards/create-one.js
@@ -73,6 +73,8 @@ module.exports = {
       listId: values.list.id,
       creatorUserId: values.creatorUser.id,
       listChangedAt: new Date().toISOString(),
+      closedAt:
+        values.list.type === List.Types.CLOSED ? new Date().toISOString() : null,
     });
 
     sails.sockets.broadcast(

--- a/server/api/helpers/cards/update-one.js
+++ b/server/api/helpers/cards/update-one.js
@@ -380,6 +380,15 @@ module.exports = {
       if (values.list) {
         values.listChangedAt = new Date().toISOString();
 
+        if (values.list.type === List.Types.CLOSED && inputs.list.type !== List.Types.CLOSED) {
+          values.closedAt = new Date().toISOString();
+        } else if (
+          values.list.type !== List.Types.CLOSED &&
+          inputs.list.type === List.Types.CLOSED
+        ) {
+          values.closedAt = null;
+        }
+
         if (values.board || inputs.list.type === List.Types.TRASH) {
           values.prevListId = null;
         } else if (sails.helpers.lists.isArchiveOrTrash(values.list)) {

--- a/server/api/helpers/lists/move-cards.js
+++ b/server/api/helpers/lists/move-cards.js
@@ -58,16 +58,27 @@ module.exports = {
       values.prevListId = null;
     }
 
+    const updateValues = {
+      ...values,
+      listId: values.list.id,
+      position: null,
+      listChangedAt: new Date().toISOString(),
+    };
+
+    if (values.list.type === List.Types.CLOSED && inputs.record.type !== List.Types.CLOSED) {
+      updateValues.closedAt = new Date().toISOString();
+    } else if (
+      values.list.type !== List.Types.CLOSED &&
+      inputs.record.type === List.Types.CLOSED
+    ) {
+      updateValues.closedAt = null;
+    }
+
     const cards = await Card.qm.update(
       {
         listId: inputs.record.id,
       },
-      {
-        ...values,
-        listId: values.list.id,
-        position: null,
-        listChangedAt: new Date().toISOString(),
-      },
+      updateValues,
     );
 
     const actions = await Action.qm.create(

--- a/server/api/models/Card.js
+++ b/server/api/models/Card.js
@@ -65,6 +65,10 @@ module.exports = {
       type: 'ref',
       columnName: 'list_changed_at',
     },
+    closedAt: {
+      type: 'ref',
+      columnName: 'closed_at',
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/server/db/migrations/20250726120000_add_closed_at_to_card.js
+++ b/server/db/migrations/20250726120000_add_closed_at_to_card.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.table('card', (table) => {
+    table.timestamp('closed_at', true);
+  });
+};
+
+exports.down = (knex) =>
+  knex.schema.table('card', (table) => {
+    table.dropColumn('closed_at');
+  });
+


### PR DESCRIPTION
## Summary
- track when cards are marked as done via `closed_at` timestamp
- set this date when creating cards in Closed lists
- update timestamp when moving cards between lists
- add migration for the new column

## Testing
- `npm run server:test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cde38a6088323b0c49b4e3b010241