### PR TITLE
Add sprint management

### DIFF
--- a/server/api/controllers/projects/start-sprint.js
+++ b/server/api/controllers/projects/start-sprint.js
@@ -1,0 +1,50 @@
+const { idInput } = require('../../../utils/inputs');
+
+const Errors = {
+  NOT_ENOUGH_RIGHTS: { notEnoughRights: 'Not enough rights' },
+  PROJECT_NOT_FOUND: { projectNotFound: 'Project not found' },
+  SCRUM_NOT_ENABLED: { scrumNotEnabled: 'Scrum not enabled for project' },
+};
+
+module.exports = {
+  inputs: {
+    projectId: { ...idInput, required: true },
+  },
+
+  exits: {
+    notEnoughRights: { responseType: 'forbidden' },
+    projectNotFound: { responseType: 'notFound' },
+    scrumNotEnabled: { responseType: 'unprocessableEntity' },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    const project = await Project.qm.getOneById(inputs.projectId);
+
+    if (!project) {
+      throw Errors.PROJECT_NOT_FOUND;
+    }
+
+    const isProjectManager = await sails.helpers.users.isProjectManager(
+      currentUser.id,
+      project.id,
+    );
+
+    if (!isProjectManager) {
+      throw Errors.NOT_ENOUGH_RIGHTS;
+    }
+
+    if (!project.useScrum) {
+      throw Errors.SCRUM_NOT_ENABLED;
+    }
+
+    const sprint = await sails.helpers.projects.startSprint.with({
+      project,
+      actorUser: currentUser,
+      request: this.req,
+    });
+
+    return { item: sprint };
+  },
+};

--- a/server/api/helpers/cards/update-one.js
+++ b/server/api/helpers/cards/update-one.js
@@ -513,6 +513,29 @@ module.exports = {
         }),
         user: inputs.actorUser,
       });
+
+      if (project.useScrum) {
+        const sprintBoard = (await Board.qm.getByProjectId(project.id)).find(
+          (b) => b.name === 'Sprint',
+        );
+
+        if (sprintBoard && inputs.board.id !== sprintBoard.id && card.boardId === sprintBoard.id) {
+          const sprint = await Sprint.qm.getOneCurrentByProjectId(project.id);
+          if (sprint) {
+            try {
+              await SprintCard.qm.createOne({
+                sprintId: sprint.id,
+                cardId: card.id,
+                addedAt: new Date().toISOString(),
+              });
+            } catch (error) {
+              if (error.code !== 'E_UNIQUE') {
+                throw error;
+              }
+            }
+          }
+        }
+      }
     }
 
     if (!_.isUndefined(isSubscribed)) {

--- a/server/api/helpers/projects/start-sprint.js
+++ b/server/api/helpers/projects/start-sprint.js
@@ -1,0 +1,96 @@
+const { POSITION_GAP } = require('../../../constants');
+
+module.exports = {
+  inputs: {
+    project: { type: 'ref', required: true },
+    actorUser: { type: 'ref', required: true },
+    request: { type: 'ref' },
+  },
+
+  async fn({ project, actorUser, request }) {
+    if (!project.useScrum) {
+      return null;
+    }
+
+    const boards = await Board.qm.getByProjectId(project.id);
+    const backlog = boards.find((b) => b.name === 'Backlog');
+    const sprintBoard = boards.find((b) => b.name === 'Sprint');
+
+    if (!backlog || !sprintBoard) {
+      return null;
+    }
+
+    const backlogLists = await List.qm.getByBoardId(backlog.id);
+    const readyList = backlogLists.find((l) => l.slug === 'ready-for-sprint');
+
+    const sprintLists = await List.qm.getByBoardId(sprintBoard.id);
+    const todoList = sprintLists.find((l) => l.slug === 'sprint-todo');
+    const doneList = sprintLists.find((l) => l.type === List.Types.CLOSED);
+    const archiveList = sprintLists.find((l) => l.type === List.Types.ARCHIVE);
+
+    if (!readyList || !todoList || !doneList || !archiveList) {
+      return null;
+    }
+
+    await sails.helpers.lists.moveCards.with({
+      project,
+      board: sprintBoard,
+      record: doneList,
+      values: { list: archiveList },
+      actorUser,
+      request,
+    });
+
+    const readyCards = await Card.qm.getByListId(readyList.id);
+    const todoCards = await Card.qm.getByListId(todoList.id);
+    let position = todoCards.reduce((max, c) => Math.max(max, c.position), 0);
+
+    const webhooks = await Webhook.qm.getAll();
+
+    const movedCards = [];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const card of readyCards) {
+      position += POSITION_GAP;
+      // eslint-disable-next-line no-await-in-loop
+      const updated = await sails.helpers.cards.updateOne.with({
+        webhooks,
+        record: card,
+        values: { board: sprintBoard, list: todoList, position },
+        project,
+        board: backlog,
+        list: readyList,
+        actorUser,
+        request,
+      });
+      movedCards.push(updated);
+    }
+
+    let sprint = await Sprint.qm.getOneCurrentByProjectId(project.id);
+    const now = new Date();
+
+    if (sprint) {
+      await Sprint.qm.updateOne(sprint.id, { closeDate: now.toISOString() });
+    }
+
+    const last = (await Sprint.qm.getByProjectId(project.id, { sort: ['number DESC'] }))[0];
+    const number = last ? last.number + 1 : 1;
+    const endDate = new Date(now.getTime() + project.sprintDuration * 7 * 24 * 60 * 60 * 1000);
+
+    sprint = await Sprint.qm.createOne({
+      projectId: project.id,
+      number,
+      startDate: now.toISOString(),
+      endDate: endDate.toISOString(),
+    });
+
+    await SprintCard.qm.create(
+      movedCards.map((card) => ({
+        sprintId: sprint.id,
+        cardId: card.id,
+        addedAt: now.toISOString(),
+      })),
+    );
+
+    return sprint;
+  },
+};

--- a/server/api/hooks/query-methods/models/Sprint.js
+++ b/server/api/hooks/query-methods/models/Sprint.js
@@ -1,0 +1,31 @@
+const defaultFind = (criteria, { sort = 'number' } = {}) =>
+  Sprint.find(criteria).sort(sort);
+
+const createOne = (values) => Sprint.create({ ...values }).fetch();
+
+const getByProjectId = (projectId, { sort = 'number' } = {}) =>
+  defaultFind({ projectId }, { sort });
+
+const getOneCurrentByProjectId = (projectId) =>
+  Sprint.findOne({ projectId, closeDate: null });
+
+const getOneById = (id, { projectId } = {}) => {
+  const criteria = { id };
+  if (projectId) {
+    criteria.projectId = projectId;
+  }
+  return Sprint.findOne(criteria);
+};
+
+const updateOne = (criteria, values) => Sprint.updateOne(criteria).set({ ...values });
+
+const deleteOne = (criteria) => Sprint.destroyOne(criteria);
+
+module.exports = {
+  createOne,
+  getByProjectId,
+  getOneCurrentByProjectId,
+  getOneById,
+  updateOne,
+  deleteOne,
+};

--- a/server/api/hooks/query-methods/models/SprintCard.js
+++ b/server/api/hooks/query-methods/models/SprintCard.js
@@ -1,0 +1,22 @@
+const defaultFind = (criteria) => SprintCard.find(criteria).sort('id');
+
+const create = (arrayOfValues) => SprintCard.createEach(arrayOfValues).fetch();
+
+const createOne = (values) => SprintCard.create({ ...values }).fetch();
+
+const getBySprintId = (sprintId) => defaultFind({ sprintId });
+
+const getByCardId = (cardId) => defaultFind({ cardId });
+
+const deleteByCardId = (cardId) => SprintCard.destroy({ cardId }).fetch();
+
+const deleteOne = (criteria) => SprintCard.destroyOne(criteria);
+
+module.exports = {
+  create,
+  createOne,
+  getBySprintId,
+  getByCardId,
+  deleteByCardId,
+  deleteOne,
+};

--- a/server/api/models/Card.js
+++ b/server/api/models/Card.js
@@ -132,5 +132,10 @@ module.exports = {
       collection: 'Action',
       via: 'cardId',
     },
+    sprints: {
+      collection: 'Sprint',
+      via: 'cardId',
+      through: 'SprintCard',
+    },
   },
 };

--- a/server/api/models/Sprint.js
+++ b/server/api/models/Sprint.js
@@ -1,0 +1,34 @@
+module.exports = {
+  attributes: {
+    number: {
+      type: 'number',
+      required: true,
+    },
+    startDate: {
+      type: 'ref',
+      columnName: 'start_date',
+      required: true,
+    },
+    endDate: {
+      type: 'ref',
+      columnName: 'end_date',
+      required: true,
+    },
+    closeDate: {
+      type: 'ref',
+      columnName: 'close_date',
+      allowNull: true,
+    },
+    projectId: {
+      model: 'Project',
+      required: true,
+      columnName: 'project_id',
+    },
+    cards: {
+      collection: 'Card',
+      via: 'sprintId',
+      through: 'SprintCard',
+    },
+  },
+  tableName: 'sprint',
+};

--- a/server/api/models/Sprint.js
+++ b/server/api/models/Sprint.js
@@ -17,7 +17,6 @@ module.exports = {
     closeDate: {
       type: 'ref',
       columnName: 'close_date',
-      allowNull: true,
     },
     projectId: {
       model: 'Project',

--- a/server/api/models/SprintCard.js
+++ b/server/api/models/SprintCard.js
@@ -1,0 +1,19 @@
+module.exports = {
+  attributes: {
+    sprintId: {
+      model: 'Sprint',
+      required: true,
+      columnName: 'sprint_id',
+    },
+    cardId: {
+      model: 'Card',
+      required: true,
+      columnName: 'card_id',
+    },
+    addedAt: {
+      type: 'ref',
+      columnName: 'added_at',
+    },
+  },
+  tableName: 'sprint_card',
+};

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -88,6 +88,7 @@ module.exports.routes = {
   'GET /api/projects/:id': 'projects/show',
   'PATCH /api/projects/:id': 'projects/update',
   'DELETE /api/projects/:id': 'projects/delete',
+  'POST /api/projects/:projectId/start-sprint': 'projects/start-sprint',
 
   'POST /api/projects/:projectId/project-managers': 'project-managers/create',
   'DELETE /api/project-managers/:id': 'project-managers/delete',

--- a/server/db/migrations/20250801120000_create_sprints.js
+++ b/server/db/migrations/20250801120000_create_sprints.js
@@ -1,0 +1,31 @@
+exports.up = async (knex) => {
+  await knex.schema.createTable('sprint', (table) => {
+    table.bigInteger('id').primary().defaultTo(knex.raw('next_id()'));
+    table.bigInteger('project_id').notNullable();
+    table.integer('number').notNullable();
+    table.date('start_date').notNullable();
+    table.date('end_date').notNullable();
+    table.timestamp('close_date', true);
+    table.timestamp('created_at', true);
+    table.timestamp('updated_at', true);
+    table.index('project_id');
+    table.unique(['project_id', 'number']);
+  });
+
+  await knex.schema.createTable('sprint_card', (table) => {
+    table.bigInteger('id').primary().defaultTo(knex.raw('next_id()'));
+    table.bigInteger('sprint_id').notNullable();
+    table.bigInteger('card_id').notNullable();
+    table.timestamp('added_at', true).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('created_at', true);
+    table.timestamp('updated_at', true);
+    table.index('sprint_id');
+    table.index('card_id');
+    table.unique(['sprint_id', 'card_id']);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.dropTable('sprint_card');
+  await knex.schema.dropTable('sprint');
+};


### PR DESCRIPTION
## Summary
- create Sprint and SprintCard tables with migrations
- add Sprint models and query methods
- update Card model with relation to sprints
- implement helper and controller to start a sprint
- update card update helper to track cards added to Sprint board
- register start-sprint route

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf76bc7608323b346b12dc9dd1b79