### PR TITLE
Fix sprint start refreshing banner

### DIFF
--- a/client/src/api/sprints.js
+++ b/client/src/api/sprints.js
@@ -8,6 +8,10 @@ import socket from './socket';
 const getCurrentSprint = (projectId, headers) =>
   socket.get(`/projects/${projectId}/current-sprint`, undefined, headers);
 
+const startSprint = (projectId, headers) =>
+  socket.post(`/projects/${projectId}/start-sprint`, undefined, headers);
+
 export default {
   getCurrentSprint,
+  startSprint,
 };

--- a/client/src/components/boards/SprintBanner/SprintBanner.jsx
+++ b/client/src/components/boards/SprintBanner/SprintBanner.jsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import api from '../../../api';
+import eventBus from '../../../utils/event-bus';
 import selectors from '../../../selectors';
 import { ListTypes } from '../../../constants/Enums';
 
@@ -23,19 +24,25 @@ const SprintBanner = React.memo(() => {
   useEffect(() => {
     let isMounted = true;
 
-    api
-      .getCurrentSprint(projectId)
-      .then(({ item }) => {
-        if (isMounted) {
-          setSprint(item);
-        }
-      })
-      .catch(() => {
-        /* ignore */
-      });
+    const fetchSprint = () => {
+      api
+        .getCurrentSprint(projectId)
+        .then(({ item }) => {
+          if (isMounted) {
+            setSprint(item);
+          }
+        })
+        .catch(() => {
+          /* ignore */
+        });
+    };
+
+    fetchSprint();
+    eventBus.on('sprintStarted', fetchSprint);
 
     return () => {
       isMounted = false;
+      eventBus.off('sprintStarted', fetchSprint);
     };
   }, [projectId]);
 

--- a/client/src/components/lists/List/StartSprintStep.jsx
+++ b/client/src/components/lists/List/StartSprintStep.jsx
@@ -5,20 +5,20 @@
 
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { Button, Form } from 'semantic-ui-react';
 import { Input, Popup } from '../../../lib/custom-ui';
 
 import selectors from '../../../selectors';
-import entryActions from '../../../entry-actions';
+import api from '../../../api';
+import eventBus from '../../../utils/event-bus';
 import { useForm } from '../../../hooks';
 import { ListTypes } from '../../../constants/Enums';
 
 import styles from './StartSprintStep.module.scss';
 
 const StartSprintStep = React.memo(({ onClose }) => {
-  const dispatch = useDispatch();
   const [t] = useTranslation();
 
   const project = useSelector(selectors.selectCurrentProject);
@@ -96,13 +96,16 @@ const StartSprintStep = React.memo(({ onClose }) => {
   const isConfirmDisabled =
     !data.startDate || !data.endDate || data.startDate >= data.endDate || readyCardIds.length === 0;
 
-  const handleConfirm = useCallback(() => {
-    if (doneListId) {
-      dispatch(entryActions.moveListCardsToArchiveList(doneListId));
+  const handleConfirm = useCallback(async () => {
+    try {
+      await api.startSprint(projectId);
+      eventBus.emit('sprintStarted');
+    } catch {
+      /* ignore */
     }
-    dispatch(entryActions.moveListCardsToSlug('ready-for-sprint', 'sprint-todo'));
+
     onClose();
-  }, [dispatch, doneListId, onClose]);
+  }, [projectId, onClose]);
 
   return (
     <>

--- a/client/src/utils/event-bus.js
+++ b/client/src/utils/event-bus.js
@@ -1,0 +1,26 @@
+class EventBus {
+  constructor() {
+    this.handlers = {};
+  }
+
+  on(event, fn) {
+    if (!this.handlers[event]) {
+      this.handlers[event] = new Set();
+    }
+    this.handlers[event].add(fn);
+  }
+
+  off(event, fn) {
+    if (this.handlers[event]) {
+      this.handlers[event].delete(fn);
+    }
+  }
+
+  emit(event, ...args) {
+    if (this.handlers[event]) {
+      this.handlers[event].forEach((fn) => fn(...args));
+    }
+  }
+}
+
+export default new EventBus();


### PR DESCRIPTION
## Summary
- add `startSprint` API client method
- handle sprint start directly in UI and emit an event
- listen for sprint start event in SprintBanner and reload sprint info
- add a small event bus utility

## Testing
- `npm test` *(fails: `userconfig` hook could not load)*
- `npm test` in `client`

------
https://chatgpt.com/codex/tasks/task_e_686d108899848323a7a71e553a5d89cd