### PR TITLE
Fix sprint banner authorization

### DIFF
--- a/client/src/components/boards/SprintBanner/SprintBanner.jsx
+++ b/client/src/components/boards/SprintBanner/SprintBanner.jsx
@@ -17,6 +17,7 @@ const SprintBanner = React.memo(() => {
   const { projectId } = useSelector(selectors.selectPath);
   const board = useSelector(selectors.selectCurrentBoard);
   const project = useSelector(selectors.selectCurrentProject);
+  const accessToken = useSelector(selectors.selectAccessToken);
   const [sprint, setSprint] = useState(null);
   const [t, i18n] = useTranslation();
 
@@ -24,7 +25,9 @@ const SprintBanner = React.memo(() => {
     let isMounted = true;
 
     api
-      .getCurrentSprint(projectId)
+      .getCurrentSprint(projectId, {
+        Authorization: `Bearer ${accessToken}`,
+      })
       .then(({ item }) => {
         if (isMounted) {
           setSprint(item);
@@ -37,7 +40,7 @@ const SprintBanner = React.memo(() => {
     return () => {
       isMounted = false;
     };
-  }, [projectId]);
+  }, [projectId, accessToken]);
 
   const selectFiniteListIdsByBoardId = useMemo(
     () => selectors.makeSelectFiniteListIdsByBoardId(),

--- a/client/src/components/lists/List/StartSprintStep.jsx
+++ b/client/src/components/lists/List/StartSprintStep.jsx
@@ -98,13 +98,9 @@ const StartSprintStep = React.memo(({ onClose }) => {
 
   const handleConfirm = useCallback(async () => {
     try {
-      await socket.post(
-        `/projects/${projectId}/start-sprint`,
-        undefined,
-        {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      );
+      await socket.post(`/projects/${projectId}/start-sprint`, undefined, {
+        Authorization: `Bearer ${accessToken}`,
+      });
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
## Summary
- ensure sprint info banner includes auth token
- tidy start sprint call formatting

## Testing
- `npm test` *(fails: hook `userconfig` failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_686d1e9059e88323aa729e8d3c27fb6b