### PR TITLE
Fix SprintBanner layout

### DIFF
--- a/client/src/components/boards/Board/Board.jsx
+++ b/client/src/components/boards/Board/Board.jsx
@@ -15,6 +15,7 @@ import EndlessContent from './EndlessContent';
 import CardModal from '../../cards/CardModal';
 import BoardActivitiesModal from '../../activities/BoardActivitiesModal';
 import SprintBanner from '../SprintBanner';
+import styles from './Board.module.scss';
 
 const Board = React.memo(() => {
   const board = useSelector(selectors.selectCurrentBoard);
@@ -55,11 +56,11 @@ const Board = React.memo(() => {
   }
 
   return (
-    <>
+    <div className={styles.wrapper}>
       {project && project.useScrum && board.name === 'Sprint' && <SprintBanner />}
       <Content />
       {modalNode}
-    </>
+    </div>
   );
 });
 

--- a/client/src/components/boards/Board/Board.module.scss
+++ b/client/src/components/boards/Board/Board.module.scss
@@ -1,0 +1,8 @@
+:global(#app) {
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    width: 100%;
+  }
+}

--- a/client/src/components/boards/SprintBanner/SprintBanner.module.scss
+++ b/client/src/components/boards/SprintBanner/SprintBanner.module.scss
@@ -1,14 +1,15 @@
 :global(#app) {
   .wrapper {
-    background-color: rgba(248, 248, 248, 0.93);
-    border-bottom: 1px solid #E0E0E0;
-    padding: 8px 20px;
+    background-color: rgba(248, 248, 248, 0.7);
+    padding: 0 20px;
+    height: 32px;
     width: 100%;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
     gap: 20px;
+    margin-bottom: 15px;
   }
 
   .item {

--- a/client/src/components/boards/SprintBanner/SprintBanner.module.scss
+++ b/client/src/components/boards/SprintBanner/SprintBanner.module.scss
@@ -3,8 +3,11 @@
     background-color: rgba(248, 248, 248, 0.93);
     border-bottom: 1px solid #E0E0E0;
     padding: 8px 20px;
+    width: 100%;
     display: flex;
+    flex-direction: row;
     flex-wrap: wrap;
+    align-items: center;
     gap: 20px;
   }
 


### PR DESCRIPTION
## Summary
- update `SprintBanner` styles to use full width and horizontal flex layout

## Testing
- `npm run client:lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d23ad4aa8832386339440f29936cf