### PR TITLE
Add Sprint statistics modal with burndown chart

### DIFF
--- a/client/src/api/sprints.js
+++ b/client/src/api/sprints.js
@@ -8,10 +8,17 @@ import socket from './socket';
 const getCurrentSprint = (projectId, headers) =>
   socket.get(`/projects/${projectId}/current-sprint`, undefined, headers);
 
+const getSprints = (projectId, headers) =>
+  socket.get(`/projects/${projectId}/sprints`, undefined, headers);
+
+const getSprint = (id, headers) => socket.get(`/sprints/${id}`, undefined, headers);
+
 const startSprint = (projectId, headers) =>
   socket.post(`/projects/${projectId}/start-sprint`, undefined, headers);
 
 export default {
   getCurrentSprint,
+  getSprints,
+  getSprint,
   startSprint,
 };

--- a/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.jsx
+++ b/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.jsx
@@ -3,10 +3,13 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'semantic-ui-react';
+
+import api from '../../../api';
+import selectors from '../../../selectors';
 
 import entryActions from '../../../entry-actions';
 import { useClosableModal } from '../../../hooks';
@@ -14,14 +17,120 @@ import { useClosableModal } from '../../../hooks';
 import styles from './SprintStatisticsModal.module.scss';
 
 const SprintStatisticsModal = React.memo(() => {
+  const { projectId } = useSelector(selectors.selectPath);
+  const accessToken = useSelector(selectors.selectAccessToken);
+  const project = useSelector(selectors.selectCurrentProject);
   const dispatch = useDispatch();
-  const [t] = useTranslation();
+  const [t, i18n] = useTranslation();
+
+  const [sprints, setSprints] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [detail, setDetail] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    api
+      .getSprints(projectId, { Authorization: `Bearer ${accessToken}` })
+      .then(({ items }) => {
+        if (isMounted) {
+          setSprints(items);
+          if (items.length > 0) {
+            setSelectedId(items[0].id);
+          }
+        }
+      })
+      .catch(() => {
+        /* ignore */
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [projectId, accessToken]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null);
+      return;
+    }
+
+    let isMounted = true;
+    api
+      .getSprint(selectedId, { Authorization: `Bearer ${accessToken}` })
+      .then(({ item, included }) => {
+        if (isMounted) {
+          setDetail({ sprint: item, cards: included.cards || [] });
+        }
+      })
+      .catch(() => {
+        /* ignore */
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedId, accessToken]);
 
   const handleClose = useCallback(() => {
     dispatch(entryActions.closeModal());
   }, [dispatch]);
 
   const [ClosableModal] = useClosableModal();
+
+  const formatDate = useCallback((iso) => new Date(iso).toLocaleDateString(i18n.language), [i18n.language]);
+
+  const totalPoints = useMemo(
+    () =>
+      detail && project.useStoryPoints
+        ? detail.cards.reduce((sum, c) => sum + c.storyPoints, 0)
+        : 0,
+    [detail, project.useStoryPoints],
+  );
+
+  const burndownData = useMemo(() => {
+    if (!detail || !project.useStoryPoints) {
+      return [];
+    }
+
+    const start = new Date(detail.sprint.startDate);
+    const end = new Date(detail.sprint.endDate);
+    const days = Math.ceil((end - start) / (1000 * 60 * 60 * 24));
+    const sorted = detail.cards
+      .filter((c) => c.closedAt)
+      .sort((a, b) => new Date(a.closedAt) - new Date(b.closedAt));
+
+    let remaining = totalPoints;
+    let index = 0;
+    const result = [];
+    for (let i = 0; i <= days; i += 1) {
+      const date = new Date(start.getTime() + i * 24 * 60 * 60 * 1000);
+      while (index < sorted.length && new Date(sorted[index].closedAt) <= date) {
+        remaining -= sorted[index].storyPoints;
+        index += 1;
+      }
+      result.push({ date, remaining: Math.max(remaining, 0) });
+    }
+    return result;
+  }, [detail, project.useStoryPoints, totalPoints]);
+
+  const chart = useMemo(() => {
+    if (burndownData.length === 0 || totalPoints === 0) {
+      return null;
+    }
+
+    const width = 400;
+    const height = 200;
+    const stepX = width / (burndownData.length - 1);
+    const points = burndownData
+      .map((p, i) => {
+        const x = i * stepX;
+        const y = height - (p.remaining / totalPoints) * height;
+        return `${x},${y}`;
+      })
+      .join(' ');
+
+    return { width, height, points };
+  }, [burndownData, totalPoints]);
 
   return (
     <ClosableModal
@@ -34,7 +143,54 @@ const SprintStatisticsModal = React.memo(() => {
       <ClosableModal.Header>
         {t('common.sprintStatistics', { context: 'title' })}
       </ClosableModal.Header>
-      <ClosableModal.Content />
+      <ClosableModal.Content>
+        <div className={styles.content}>
+          <div className={styles.sidebar}>
+            {sprints.map((s) => (
+              <div
+                key={s.id}
+                role="button"
+                tabIndex={0}
+                className={
+                  s.id === selectedId ? styles.activeItem : styles.item
+                }
+                onClick={() => setSelectedId(s.id)}
+                onKeyPress={() => setSelectedId(s.id)}
+              >
+                {`Sprint ${s.number}`}
+              </div>
+            ))}
+          </div>
+          <div className={styles.details}>
+            {detail && (
+              <>
+                <div className={styles.field}>{`Sprint ${detail.sprint.number}`}</div>
+                <div className={styles.field}>{`${t('common.startDate')}: ${formatDate(detail.sprint.startDate)}`}</div>
+                <div className={styles.field}>{`${t('common.endDate')}: ${formatDate(detail.sprint.endDate)}`}</div>
+                {project.useStoryPoints && (
+                  <>
+                    <div className={styles.field}>{`${t('common.totalSprintPoints')}: ${totalPoints}`}</div>
+                    {chart && (
+                      <svg
+                        className={styles.chart}
+                        width={chart.width}
+                        height={chart.height}
+                      >
+                        <polyline
+                          points={chart.points}
+                          fill="none"
+                          stroke="orange"
+                          strokeWidth="2"
+                        />
+                      </svg>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </ClosableModal.Content>
       <ClosableModal.Actions>
         <Button onClick={handleClose} content={t('action.close')} />
       </ClosableModal.Actions>

--- a/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.jsx
+++ b/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.jsx
@@ -141,7 +141,7 @@ const SprintStatisticsModal = React.memo(() => {
       onClose={handleClose}
     >
       <ClosableModal.Header>
-        {t('common.sprintStatistics', { context: 'title' })}
+        {t('common.sprintStatistics_title')}
       </ClosableModal.Header>
       <ClosableModal.Content>
         <div className={styles.content}>

--- a/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.module.scss
+++ b/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.module.scss
@@ -3,4 +3,39 @@
     margin: 15px !important;
     width: calc(100% - 30px) !important;
   }
+
+  .content {
+    display: flex;
+    gap: 20px;
+  }
+
+  .sidebar {
+    width: 20%;
+    min-width: 150px;
+    border-right: 1px solid #555;
+    padding-right: 10px;
+  }
+
+  .item {
+    cursor: pointer;
+    padding: 4px 0;
+  }
+
+  .activeItem {
+    composes: item;
+    font-weight: bold;
+  }
+
+  .details {
+    flex: 1;
+  }
+
+  .field {
+    margin-bottom: 8px;
+  }
+
+  .chart {
+    width: 100%;
+    margin-top: 10px;
+  }
 }

--- a/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.module.scss
+++ b/client/src/components/sprints/SprintStatisticsModal/SprintStatisticsModal.module.scss
@@ -21,10 +21,11 @@
     padding: 4px 0;
   }
 
-  .activeItem {
-    composes: item;
-    font-weight: bold;
-  }
+    .activeItem {
+      cursor: pointer;
+      padding: 4px 0;
+      font-weight: bold;
+    }
 
   .details {
     flex: 1;

--- a/server/api/controllers/sprints/index.js
+++ b/server/api/controllers/sprints/index.js
@@ -1,0 +1,49 @@
+const { idInput } = require('../../utils/inputs');
+
+const Errors = {
+  NOT_ENOUGH_RIGHTS: { notEnoughRights: 'Not enough rights' },
+  PROJECT_NOT_FOUND: { projectNotFound: 'Project not found' },
+};
+
+module.exports = {
+  inputs: {
+    projectId: { ...idInput, required: true },
+  },
+
+  exits: {
+    notEnoughRights: { responseType: 'forbidden' },
+    projectNotFound: { responseType: 'notFound' },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    const project = await Project.qm.getOneById(inputs.projectId);
+
+    if (!project) {
+      throw Errors.PROJECT_NOT_FOUND;
+    }
+
+    const isProjectManager = await sails.helpers.users.isProjectManager(
+      currentUser.id,
+      project.id,
+    );
+
+    if (!isProjectManager) {
+      const boardMemberships = await BoardMembership.qm.getByProjectIdAndUserId(
+        project.id,
+        currentUser.id,
+      );
+
+      if (boardMemberships.length === 0) {
+        throw Errors.NOT_ENOUGH_RIGHTS;
+      }
+    }
+
+    const sprints = await Sprint.qm.getByProjectId(project.id, {
+      sort: ['startDate DESC'],
+    });
+
+    return { items: sprints };
+  },
+};

--- a/server/api/controllers/sprints/index.js
+++ b/server/api/controllers/sprints/index.js
@@ -1,4 +1,4 @@
-const { idInput } = require('../../utils/inputs');
+const { idInput } = require('../../../utils/inputs');
 
 const Errors = {
   NOT_ENOUGH_RIGHTS: { notEnoughRights: 'Not enough rights' },

--- a/server/api/controllers/sprints/show.js
+++ b/server/api/controllers/sprints/show.js
@@ -1,0 +1,54 @@
+const { idInput } = require('../../utils/inputs');
+
+const Errors = {
+  SPRINT_NOT_FOUND: { sprintNotFound: 'Sprint not found' },
+};
+
+module.exports = {
+  inputs: {
+    id: { ...idInput, required: true },
+  },
+
+  exits: {
+    sprintNotFound: { responseType: 'notFound' },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    const sprint = await Sprint.qm.getOneById(inputs.id);
+
+    if (!sprint) {
+      throw Errors.SPRINT_NOT_FOUND;
+    }
+
+    const project = await Project.qm.getOneById(sprint.projectId);
+
+    const isProjectManager = await sails.helpers.users.isProjectManager(
+      currentUser.id,
+      project.id,
+    );
+
+    if (!isProjectManager) {
+      const boardMemberships = await BoardMembership.qm.getByProjectIdAndUserId(
+        project.id,
+        currentUser.id,
+      );
+
+      if (boardMemberships.length === 0) {
+        throw Errors.SPRINT_NOT_FOUND; // Forbidden
+      }
+    }
+
+    const sprintCards = await SprintCard.qm.getBySprintId(sprint.id);
+    const cardIds = sails.helpers.utils.mapRecords(sprintCards, 'cardId');
+    const cards = cardIds.length > 0 ? await Card.qm.getByIds(cardIds) : [];
+
+    return {
+      item: sprint,
+      included: {
+        cards,
+      },
+    };
+  },
+};

--- a/server/api/controllers/sprints/show.js
+++ b/server/api/controllers/sprints/show.js
@@ -1,4 +1,4 @@
-const { idInput } = require('../../utils/inputs');
+const { idInput } = require('../../../utils/inputs');
 
 const Errors = {
   SPRINT_NOT_FOUND: { sprintNotFound: 'Sprint not found' },

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -90,6 +90,8 @@ module.exports.routes = {
   'DELETE /api/projects/:id': 'projects/delete',
   'POST /api/projects/:projectId/start-sprint': 'projects/start-sprint',
   'GET /api/projects/:projectId/current-sprint': 'sprints/current',
+  'GET /api/projects/:projectId/sprints': 'sprints/index',
+  'GET /api/sprints/:id': 'sprints/show',
 
   'POST /api/projects/:projectId/project-managers': 'project-managers/create',
   'DELETE /api/project-managers/:id': 'project-managers/delete',


### PR DESCRIPTION
## Summary
- implement API endpoints to list sprints and get sprint details
- wire up client API helpers
- implement SprintStatisticsModal with burndown chart and sprint list
- style sprint statistics modal
- add routes for new sprint endpoints

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed473987883238fe8e7e3e8707e24