### PR TITLE
Configure Jest coverage for client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint --ext js,jsx src --report-unused-disable-directives",
     "format": "eslint --ext js,jsx src --report-unused-disable-directives --fix",
     "start": "vite",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:acceptance": "cucumber-js --import tests/acceptance/cucumber.conf.js --import tests/acceptance/steps/**/*.js --format @cucumber/pretty-formatter tests"
   },
   "babel": {


### PR DESCRIPTION
## Summary
- enable code coverage in client jest tests

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_686f856cf7e88323af02dd266ce2ee74