### PR TITLE
Show card codes for team projects

### DIFF
--- a/client/src/components/cards/Card/ProjectContent.jsx
+++ b/client/src/components/cards/Card/ProjectContent.jsx
@@ -56,6 +56,7 @@ const ProjectContent = React.memo(({ cardId }) => {
   const card = useSelector((state) => selectCardById(state, cardId));
   const list = useSelector((state) => selectListById(state, card.listId));
   const project = useSelector(selectors.selectCurrentProject);
+  const isTeamProject = !project.ownerProjectManagerId;
   const cardType = useSelector((state) => {
     if (!card.cardTypeId) {
       return null;
@@ -178,6 +179,11 @@ const ProjectContent = React.memo(({ cardId }) => {
           <StoryPointsChip value={card.storyPoints} size="tiny" className={styles.storyPoints} />
         )}
       </div>
+      {isTeamProject && (
+        <div className={styles.cardKey}>
+          {project.code}-{card.number}
+        </div>
+      )}
       {coverUrl && (
         <div className={styles.coverWrapper}>
           <img src={coverUrl} alt="" className={styles.cover} />

--- a/client/src/components/cards/Card/ProjectContent.module.scss
+++ b/client/src/components/cards/Card/ProjectContent.module.scss
@@ -103,6 +103,13 @@
     text-decoration: line-through;
   }
 
+  .cardKey {
+    color: #6b808c;
+    font-size: 10px;
+    margin-top: -2px;
+    margin-bottom: 4px;
+  }
+
   .notification {
     background: #eb5a46;
     color: #fff;

--- a/client/src/components/cards/Card/StoryContent.jsx
+++ b/client/src/components/cards/Card/StoryContent.jsx
@@ -43,6 +43,7 @@ const StoryContent = React.memo(({ cardId }) => {
   const card = useSelector((state) => selectCardById(state, cardId));
   const list = useSelector((state) => selectListById(state, card.listId));
   const project = useSelector(selectors.selectCurrentProject);
+  const isTeamProject = !project.ownerProjectManagerId;
   const labelIds = useSelector((state) => selectLabelIdsByCardId(state, cardId));
   const attachmentsTotal = useSelector((state) => selectAttachmentsTotalByCardId(state, cardId));
 
@@ -117,6 +118,11 @@ const StoryContent = React.memo(({ cardId }) => {
             <StoryPointsChip value={card.storyPoints} size="tiny" className={styles.storyPoints} />
           )}
         </div>
+        {isTeamProject && (
+          <div className={styles.cardKey}>
+            {project.code}-{card.number}
+          </div>
+        )}
         {card.description && <div className={styles.descriptionText}>{descriptionText}</div>}
         {(attachmentsTotal > 0 || notificationsTotal > 0 || listName) && (
           <span className={styles.attachments}>

--- a/client/src/components/cards/Card/StoryContent.module.scss
+++ b/client/src/components/cards/Card/StoryContent.module.scss
@@ -84,6 +84,13 @@
     text-decoration: line-through;
   }
 
+  .cardKey {
+    color: #6b808c;
+    font-size: 10px;
+    margin-top: -2px;
+    margin-bottom: 4px;
+  }
+
   .storyPoints {
     flex-shrink: 0;
     margin-left: 4px;

--- a/client/src/components/cards/CardModal/ProjectContent.jsx
+++ b/client/src/components/cards/CardModal/ProjectContent.jsx
@@ -53,6 +53,7 @@ const ProjectContent = React.memo(({ onClose }) => {
   const card = useSelector(selectors.selectCurrentCard);
   const board = useSelector(selectors.selectCurrentBoard);
   const project = useSelector(selectors.selectCurrentProject);
+  const isTeamProject = !project.ownerProjectManagerId;
   const cardType = useSelector((state) => {
     if (!card.cardTypeId) {
       return null;
@@ -353,7 +354,11 @@ const ProjectContent = React.memo(({ onClose }) => {
               ) : (
                 <div className={styles.headerTitle}>{card.name}</div>
               )}
-              <div className={styles.headerKey}>{project.code}-{card.number}</div>
+              {isTeamProject && (
+                <div className={styles.headerKey}>
+                  {project.code}-{card.number}
+                </div>
+              )}
             </div>
           </div>
         </Grid.Column>

--- a/client/src/components/cards/CardModal/StoryContent/StoryContent.jsx
+++ b/client/src/components/cards/CardModal/StoryContent/StoryContent.jsx
@@ -49,6 +49,7 @@ const StoryContent = React.memo(({ onClose }) => {
   const card = useSelector(selectors.selectCurrentCard);
   const board = useSelector(selectors.selectCurrentBoard);
   const project = useSelector(selectors.selectCurrentProject);
+  const isTeamProject = !project.ownerProjectManagerId;
   const cardType = useSelector((state) => {
     if (!card.cardTypeId) {
       return null;
@@ -345,7 +346,11 @@ const StoryContent = React.memo(({ onClose }) => {
               ) : (
                 <div className={styles.headerTitle}>{card.name}</div>
               )}
-              <div className={styles.headerKey}>{project.code}-{card.number}</div>
+              {isTeamProject && (
+                <div className={styles.headerKey}>
+                  {project.code}-{card.number}
+                </div>
+              )}
             </div>
           </div>
         </Grid.Column>


### PR DESCRIPTION
## Summary
- show card code on cards within board columns
- hide card code for personal projects in modals and cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f8df7229c832396a29e550917ae5c