### PR TITLE
Support project-based card links in tasks

### DIFF
--- a/client/src/components/task-lists/TaskList/Task/Task.jsx
+++ b/client/src/components/task-lists/TaskList/Task/Task.jsx
@@ -30,15 +30,29 @@ const Task = React.memo(({ id, index }) => {
   const selectTaskById = useMemo(() => selectors.makeSelectTaskById(), []);
   const selectListById = useMemo(() => selectors.makeSelectListById(), []);
   const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
+  const selectCardByProjectCodeAndNumber = useMemo(
+    () => selectors.makeSelectCardByProjectCodeAndNumber(),
+    [],
+  );
 
   const task = useSelector((state) => selectTaskById(state, id));
 
   const isLinkedCardCompleted = useSelector((state) => {
-    const regex = /\/cards\/([^/]+)/g;
+    const regex = /\/cards\/([^/]+)(?:\/([^/]+))?/g;
     const matches = task.name.matchAll(regex);
     // eslint-disable-next-line no-restricted-syntax
-    for (const [, cardId] of matches) {
-      const card = selectCardById(state, cardId);
+    for (const match of matches) {
+      let card;
+      if (match[2]) {
+        card = selectCardByProjectCodeAndNumber(
+          state,
+          match[1],
+          Number(match[2]),
+        );
+      } else {
+        card = selectCardById(state, match[1]);
+      }
+
       if (card) {
         const list = selectListById(state, card.listId);
         if (list && list.type === ListTypes.CLOSED) {

--- a/client/src/components/task-lists/TaskList/TaskList.jsx
+++ b/client/src/components/task-lists/TaskList/TaskList.jsx
@@ -47,6 +47,10 @@ const TaskList = React.memo(({ id }) => {
 
   // TODO: move to selector?
   const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
+  const selectCardByProjectCodeAndNumber = useMemo(
+    () => selectors.makeSelectCardByProjectCodeAndNumber(),
+    [],
+  );
 
   const completedTasksTotal = useSelector((state) =>
     tasks.reduce((result, task) => {
@@ -54,12 +58,21 @@ const TaskList = React.memo(({ id }) => {
         return result + 1;
       }
 
-      const regex = /\/cards\/([^/]+)/g;
+      const regex = /\/cards\/([^/]+)(?:\/([^/]+))?/g;
       const matches = task.name.matchAll(regex);
 
       // eslint-disable-next-line no-restricted-syntax
-      for (const [, cardId] of matches) {
-        const card = selectCardById(state, cardId);
+      for (const match of matches) {
+        let card;
+        if (match[2]) {
+          card = selectCardByProjectCodeAndNumber(
+            state,
+            match[1],
+            Number(match[2]),
+          );
+        } else {
+          card = selectCardById(state, match[1]);
+        }
 
         if (card) {
           const list = selectListById(state, card.listId);

--- a/client/src/selectors/cards.js
+++ b/client/src/selectors/cards.js
@@ -36,7 +36,7 @@ export const makeSelectCardByProjectCodeAndNumber = () =>
   createSelector(
     orm,
     (_, projectCode, number) => ({ projectCode, number: Number(number) }),
-    ({ Card, Project }, { projectCode, number }) => {
+    ({ Card, Project, Board }, { projectCode, number }) => {
       const projectModel = Project.all()
         .toModelArray()
         .find((p) => p.code === projectCode);
@@ -47,10 +47,14 @@ export const makeSelectCardByProjectCodeAndNumber = () =>
 
       const cardModel = Card.all()
         .toModelArray()
-        .find(
-          (c) =>
-            c.number === number && c.board.projectId === projectModel.id,
-        );
+        .find((c) => {
+          if (c.number !== number) {
+            return false;
+          }
+
+          const boardModel = Board.withId(c.boardId);
+          return boardModel && boardModel.projectId === projectModel.id;
+        });
 
       if (!cardModel) {
         return null;

--- a/client/src/selectors/cards.js
+++ b/client/src/selectors/cards.js
@@ -32,6 +32,39 @@ export const makeSelectCardById = () =>
 
 export const selectCardById = makeSelectCardById();
 
+export const makeSelectCardByProjectCodeAndNumber = () =>
+  createSelector(
+    orm,
+    (_, projectCode, number) => ({ projectCode, number: Number(number) }),
+    ({ Card, Project }, { projectCode, number }) => {
+      const projectModel = Project.all()
+        .toModelArray()
+        .find((p) => p.code === projectCode);
+
+      if (!projectModel) {
+        return null;
+      }
+
+      const cardModel = Card.all()
+        .toModelArray()
+        .find(
+          (c) =>
+            c.number === number && c.board.projectId === projectModel.id,
+        );
+
+      if (!cardModel) {
+        return null;
+      }
+
+      return {
+        ...cardModel.ref,
+        isPersisted: !isLocalId(cardModel.id),
+      };
+    },
+  );
+
+export const selectCardByProjectCodeAndNumber = makeSelectCardByProjectCodeAndNumber();
+
 export const selectCardNamesById = createSelector(orm, ({ Card }) =>
   Card.all()
     .toModelArray()
@@ -477,6 +510,8 @@ export const selectIsCurrentUserInCurrentCard = createSelector(
 export default {
   makeSelectCardById,
   selectCardById,
+  makeSelectCardByProjectCodeAndNumber,
+  selectCardByProjectCodeAndNumber,
   makeSelectCardIndexById,
   selectCardIndexById,
   selectCardNamesById,

--- a/client/src/selectors/router.js
+++ b/client/src/selectors/router.js
@@ -84,11 +84,14 @@ export const selectPath = createReduxOrmSelector(
             projectModel &&
             Card.all()
               .toModelArray()
-              .find(
-                (c) =>
-                  c.number === Number(pathsMatch.params.number) &&
-                  c.board.projectId === projectModel.id,
-              );
+              .find((c) => {
+                if (c.number !== Number(pathsMatch.params.number)) {
+                  return false;
+                }
+
+                const boardModel = Board.withId(c.boardId);
+                return boardModel && boardModel.projectId === projectModel.id;
+              });
 
           if (!cardModel || !cardModel.isAvailableForUser(currentUserModel)) {
             return {
@@ -98,10 +101,12 @@ export const selectPath = createReduxOrmSelector(
             };
           }
 
+          const boardModel = Board.withId(cardModel.boardId);
+
           return {
             cardId: cardModel.id,
-            boardId: cardModel.boardId,
-            projectId: cardModel.board.projectId,
+            boardId: boardModel ? boardModel.id : null,
+            projectId: boardModel ? boardModel.projectId : null,
           };
         }
         default:


### PR DESCRIPTION
## Summary
- add selector for card lookup by project code and number
- handle `/cards/<project>/<number>` links in Linkify
- detect new card link format in tasks and task lists

## Testing
- `npm test`
- `npx eslint@8 client/src/components/common/Linkify.jsx client/src/components/task-lists/TaskList/Task/Task.jsx client/src/components/task-lists/TaskList/TaskList.jsx client/src/selectors/cards.js` *(fails: Cannot find module 'babel-preset-airbnb')*

------
https://chatgpt.com/codex/tasks/task_e_686f933f850883238158c8de12fbdce0