### PR TITLE
Add Gantt dates to cards

### DIFF
--- a/client/src/api/cards.js
+++ b/client/src/api/cards.js
@@ -17,6 +17,12 @@ export const transformCard = (card) => ({
   ...(card.dueDate && {
     dueDate: new Date(card.dueDate),
   }),
+  ...(card.ganttStartDate && {
+    ganttStartDate: new Date(card.ganttStartDate),
+  }),
+  ...(card.ganttEndDate && {
+    ganttEndDate: new Date(card.ganttEndDate),
+  }),
   ...(card.stopwatch && {
     stopwatch: {
       ...card.stopwatch,
@@ -37,6 +43,12 @@ export const transformCardData = (data) => ({
   ...data,
   ...(data.dueDate && {
     dueDate: data.dueDate.toISOString(),
+  }),
+  ...(data.ganttStartDate && {
+    ganttStartDate: data.ganttStartDate.toISOString(),
+  }),
+  ...(data.ganttEndDate && {
+    ganttEndDate: data.ganttEndDate.toISOString(),
   }),
   ...(data.stopwatch && {
     stopwatch: {

--- a/client/src/models/Card.js
+++ b/client/src/models/Card.js
@@ -20,6 +20,8 @@ export default class extends BaseModel {
     name: attr(),
     description: attr(),
     dueDate: attr(),
+    ganttStartDate: attr(),
+    ganttEndDate: attr(),
     stopwatch: attr(),
     storyPoints: attr({
       getDefault: () => 0,
@@ -557,6 +559,8 @@ export default class extends BaseModel {
       name: this.name,
       description: this.description,
       dueDate: this.dueDate,
+      ganttStartDate: this.ganttStartDate,
+      ganttEndDate: this.ganttEndDate,
       stopwatch: this.stopwatch,
       storyPoints: this.storyPoints,
       ...data,

--- a/server/api/controllers/cards/create.js
+++ b/server/api/controllers/cards/create.js
@@ -55,6 +55,16 @@ module.exports = {
       type: 'string',
       custom: isDueDate,
     },
+    ganttStartDate: {
+      type: 'string',
+      custom: isDueDate,
+      allowNull: true,
+    },
+    ganttEndDate: {
+      type: 'string',
+      custom: isDueDate,
+      allowNull: true,
+    },
     stopwatch: {
       type: 'json',
       custom: isStopwatch,
@@ -107,6 +117,8 @@ module.exports = {
       'name',
       'description',
       'dueDate',
+      'ganttStartDate',
+      'ganttEndDate',
       'stopwatch',
       'cardTypeId',
       'storyPoints',

--- a/server/api/controllers/cards/update.js
+++ b/server/api/controllers/cards/update.js
@@ -77,6 +77,16 @@ module.exports = {
       custom: isDueDate,
       allowNull: true,
     },
+    ganttStartDate: {
+      type: 'string',
+      custom: isDueDate,
+      allowNull: true,
+    },
+    ganttEndDate: {
+      type: 'string',
+      custom: isDueDate,
+      allowNull: true,
+    },
     stopwatch: {
       type: 'json',
       custom: isStopwatch,
@@ -152,6 +162,8 @@ module.exports = {
         'name',
         'description',
         'dueDate',
+        'ganttStartDate',
+        'ganttEndDate',
         'stopwatch',
         'storyPoints',
       );
@@ -213,6 +225,8 @@ module.exports = {
       'name',
       'description',
       'dueDate',
+      'ganttStartDate',
+      'ganttEndDate',
       'stopwatch',
       'storyPoints',
       'isSubscribed',

--- a/server/api/helpers/cards/duplicate-one.js
+++ b/server/api/helpers/cards/duplicate-one.js
@@ -100,6 +100,8 @@ module.exports = {
         'name',
         'description',
         'dueDate',
+        'ganttStartDate',
+        'ganttEndDate',
         'stopwatch',
         'storyPoints',
       ]),

--- a/server/api/models/Card.js
+++ b/server/api/models/Card.js
@@ -52,6 +52,14 @@ module.exports = {
       type: 'ref',
       columnName: 'due_date',
     },
+    ganttStartDate: {
+      type: 'ref',
+      columnName: 'gantt_start_date',
+    },
+    ganttEndDate: {
+      type: 'ref',
+      columnName: 'gantt_end_date',
+    },
     stopwatch: {
       type: 'json',
     },

--- a/server/db/migrations/20250911120000_add_gantt_dates_to_card.js
+++ b/server/db/migrations/20250911120000_add_gantt_dates_to_card.js
@@ -1,0 +1,12 @@
+exports.up = async (knex) => {
+  await knex.schema.table('card', (table) => {
+    table.timestamp('gantt_start_date', true);
+    table.timestamp('gantt_end_date', true);
+  });
+};
+
+exports.down = (knex) =>
+  knex.schema.table('card', (table) => {
+    table.dropColumn('gantt_start_date');
+    table.dropColumn('gantt_end_date');
+  });


### PR DESCRIPTION
## Summary
- add migrations for new `gantt_start_date` and `gantt_end_date` columns
- update Card model and controllers to handle the new dates
- duplicate helper propagates the new fields
- expose Gantt dates in the client API and models

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68716636e86483238e5c12e3caf5a15b