### PR TITLE
Add project Use Epics setting

### DIFF
--- a/client/src/components/projects/ProjectSettingsModal/GeneralPane/GeneralPane.jsx
+++ b/client/src/components/projects/ProjectSettingsModal/GeneralPane/GeneralPane.jsx
@@ -137,6 +137,16 @@ const GeneralPane = React.memo(() => {
               onChange={handleSprintDurationChange}
             />
           )}
+          {project.useScrum && (
+            <Radio
+              toggle
+              name="useEpics"
+              checked={project.useEpics}
+              label={t('common.useEpics')}
+              className={styles.radio}
+              onChange={handleToggleChange}
+            />
+          )}
         </>
       )}
       {canEdit && (

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -169,6 +169,7 @@ export default {
       configuration: 'Configuration',
       useStoryPointsInProject: 'Use story points in project',
       useScrum: 'Use scrum',
+      useEpics: 'Use epics',
       sprintDuration: 'Sprint duration',
       oneWeek: '1 week',
       twoWeeks: '2 weeks',

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -179,6 +179,7 @@ export default {
       configuration: 'Configuration',
       useStoryPointsInProject: 'Utiliser les story points dans le projet',
       useScrum: 'Utiliser Scrum',
+      useEpics: 'Utiliser les epics',
       sprintDuration: 'Durée du sprint',
       oneWeek: '1 semaine',
       twoWeeks: '2 semaines',

--- a/client/src/models/Project.js
+++ b/client/src/models/Project.js
@@ -22,6 +22,7 @@ export default class extends BaseModel {
     useStoryPoints: attr(),
     useScrum: attr(),
     sprintDuration: attr(),
+    useEpics: attr(),
     isFavorite: attr({
       getDefault: () => false,
     }),

--- a/server/api/controllers/projects/update.js
+++ b/server/api/controllers/projects/update.js
@@ -74,6 +74,9 @@ module.exports = {
       type: 'number',
       isIn: [1, 2, 3, 4],
     },
+    useEpics: {
+      type: 'boolean',
+    },
     useStoryPoints: {
       type: 'boolean',
     },
@@ -141,6 +144,7 @@ module.exports = {
           'useStoryPoints',
           'useScrum',
           'sprintDuration',
+          'useEpics',
         );
       }
     } else if (currentUser.role === User.Roles.ADMIN) {
@@ -150,9 +154,16 @@ module.exports = {
         'useStoryPoints',
         'useScrum',
         'sprintDuration',
+        'useEpics',
       );
     } else if (projectManager) {
-      availableInputKeys.push('isHidden', 'useStoryPoints', 'useScrum', 'sprintDuration');
+      availableInputKeys.push(
+        'isHidden',
+        'useStoryPoints',
+        'useScrum',
+        'sprintDuration',
+        'useEpics',
+      );
     }
 
     if (projectManager) {
@@ -165,6 +176,7 @@ module.exports = {
         'useStoryPoints',
         'useScrum',
         'sprintDuration',
+        'useEpics',
       );
     }
 
@@ -225,6 +237,7 @@ module.exports = {
       'useStoryPoints',
       'useScrum',
       'sprintDuration',
+      'useEpics',
       'isFavorite',
     ]);
 

--- a/server/api/models/Project.js
+++ b/server/api/models/Project.js
@@ -103,6 +103,11 @@ module.exports = {
       defaultsTo: 2,
       columnName: 'sprint_duration',
     },
+    useEpics: {
+      type: 'boolean',
+      defaultsTo: false,
+      columnName: 'use_epics',
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/server/db/migrations/20250912120000_add_use_epics_to_project.js
+++ b/server/db/migrations/20250912120000_add_use_epics_to_project.js
@@ -1,0 +1,10 @@
+exports.up = async (knex) => {
+  await knex.schema.table('project', (table) => {
+    table.boolean('use_epics').notNullable().defaultTo(false);
+  });
+};
+
+exports.down = (knex) =>
+  knex.schema.table('project', (table) => {
+    table.dropColumn('use_epics');
+  });


### PR DESCRIPTION
## Summary
- allow projects to enable epics
- store preference in database
- add translations for English and French
- expose UI option in project settings modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68716bd0a54483239106c814ec5d1bba