### PR TITLE
Fix epic date transformation

### DIFF
--- a/client/src/components/projects/EpicEditor/EpicEditor.jsx
+++ b/client/src/components/projects/EpicEditor/EpicEditor.jsx
@@ -50,21 +50,21 @@ const EpicEditor = React.forwardRef(({ data, onFieldChange }, ref) => {
       />
       <div>{t('common.startDate')}</div>
       <DatePicker
-        selected={data.startDate ? new Date(data.startDate) : null}
+        selected={data.startDate || null}
         onChange={(date) =>
           onFieldChange(undefined, {
             name: 'startDate',
-            value: date ? date.toISOString() : null,
+            value: date || null,
           })
         }
       />
       <div>{t('common.endDate')}</div>
       <DatePicker
-        selected={data.endDate ? new Date(data.endDate) : null}
+        selected={data.endDate || null}
         onChange={(date) =>
           onFieldChange(undefined, {
             name: 'endDate',
-            value: date ? date.toISOString() : null,
+            value: date || null,
           })
         }
       />


### PR DESCRIPTION
## Summary
- fix epic date handling by storing `Date` objects instead of ISO strings in the epic editor

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873baaaa6048323b231a781fc218a3c