### PR TITLE
Fix Gantt bar date alignment

### DIFF
--- a/client/src/components/common/Gantt/Gantt.jsx
+++ b/client/src/components/common/Gantt/Gantt.jsx
@@ -127,9 +127,9 @@ const Gantt = React.memo(({ tasks, onChange }) => {
     if (!task.startDate || !task.endDate) {
       return null;
     }
-    const offsetDays = differenceInCalendarDays(startOfDay(task.startDate), range.start);
+    const offsetDays = differenceInCalendarDays(task.startDate, range.start);
     const durationDays =
-      differenceInCalendarDays(startOfDay(task.endDate), startOfDay(task.startDate)) + 1;
+      differenceInCalendarDays(task.endDate, task.startDate) + 1;
     const progressWidth = `${task.progress}%`;
     return {
       offset: offsetDays * DAY_WIDTH,


### PR DESCRIPTION
## Summary
- ensure Gantt bars use the exact start and end dates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873bccbf39c8323ac71a42b72072f7d