### PR TITLE
Fix Gantt layout so timeline scrolls

### DIFF
--- a/client/src/components/common/Gantt/Gantt.jsx
+++ b/client/src/components/common/Gantt/Gantt.jsx
@@ -140,8 +140,17 @@ const Gantt = React.memo(({ tasks, onChange }) => {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.headerRow}>
+      <div className={styles.leftPane}>
         <div className={styles.leftHeader}>{t('common.epics')}</div>
+        <div className={styles.leftColumn}>
+          {localTasks.map((task) => (
+            <div key={task.id} className={styles.epicRow} style={{ height: ROW_HEIGHT }}>
+              {task.name}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className={styles.rightPane}>
         <div className={styles.rightHeader} ref={headerRef} onScroll={handleHeaderScroll}>
           <div className={styles.monthRow} style={{ width: range.totalDays * DAY_WIDTH }}>
             {months.map((month) => (
@@ -161,15 +170,6 @@ const Gantt = React.memo(({ tasks, onChange }) => {
               </div>
             ))}
           </div>
-        </div>
-      </div>
-      <div className={styles.body}>
-        <div className={styles.leftColumn}>
-          {localTasks.map((task) => (
-            <div key={task.id} className={styles.epicRow} style={{ height: ROW_HEIGHT }}>
-              {task.name}
-            </div>
-          ))}
         </div>
         <div className={styles.rightColumn} ref={bodyRef} onScroll={handleBodyScroll}>
           <div className={styles.timeline} style={{ width: range.totalDays * DAY_WIDTH }}>

--- a/client/src/components/common/Gantt/Gantt.jsx
+++ b/client/src/components/common/Gantt/Gantt.jsx
@@ -140,18 +140,8 @@ const Gantt = React.memo(({ tasks, onChange }) => {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.leftPane}>
-        <div className={styles.leftHeader}>{t('common.epics')}</div>
-        <div className={styles.leftColumn}>
-          {localTasks.map((task) => (
-            <div key={task.id} className={styles.epicRow} style={{ height: ROW_HEIGHT }}>
-              {task.name}
-            </div>
-          ))}
-        </div>
-      </div>
-      <div className={styles.rightPane}>
-        <div className={styles.rightHeader} ref={headerRef} onScroll={handleHeaderScroll}>
+      <div className={styles.leftHeader}>{t('common.epics')}</div>
+      <div className={styles.rightHeader} ref={headerRef} onScroll={handleHeaderScroll}>
           <div className={styles.monthRow} style={{ width: range.totalDays * DAY_WIDTH }}>
             {months.map((month) => (
               <div
@@ -171,42 +161,48 @@ const Gantt = React.memo(({ tasks, onChange }) => {
             ))}
           </div>
         </div>
-        <div className={styles.rightColumn} ref={bodyRef} onScroll={handleBodyScroll}>
-          <div className={styles.timeline} style={{ width: range.totalDays * DAY_WIDTH }}>
-            {localTasks.map((task, index) => {
-              const bar = getBarStyle(task);
-              return (
-                <div key={task.id} className={styles.row} style={{ height: ROW_HEIGHT }}>
-                  {bar && (
+      <div className={styles.leftColumn}>
+        {localTasks.map((task) => (
+          <div key={task.id} className={styles.epicRow} style={{ height: ROW_HEIGHT }}>
+            {task.name}
+          </div>
+        ))}
+      </div>
+      <div className={styles.rightColumn} ref={bodyRef} onScroll={handleBodyScroll}>
+        <div className={styles.timeline} style={{ width: range.totalDays * DAY_WIDTH }}>
+          {localTasks.map((task, index) => {
+            const bar = getBarStyle(task);
+            return (
+              <div key={task.id} className={styles.row} style={{ height: ROW_HEIGHT }}>
+                {bar && (
+                  <div
+                    className={styles.bar}
+                    style={{
+                      left: bar.offset,
+                      width: bar.width,
+                      backgroundColor: task.color,
+                    }}
+                  >
                     <div
-                      className={styles.bar}
+                      className={styles.gripLeft}
+                      onMouseDown={startResize(index, 'start')}
+                    />
+                    <div
+                      className={styles.gripRight}
+                      onMouseDown={startResize(index, 'end')}
+                    />
+                    <div
+                      className={styles.progress}
                       style={{
-                        left: bar.offset,
-                        width: bar.width,
+                        width: bar.progressWidth,
                         backgroundColor: task.color,
                       }}
-                    >
-                      <div
-                        className={styles.gripLeft}
-                        onMouseDown={startResize(index, 'start')}
-                      />
-                      <div
-                        className={styles.gripRight}
-                        onMouseDown={startResize(index, 'end')}
-                      />
-                      <div
-                        className={styles.progress}
-                        style={{
-                          width: bar.progressWidth,
-                          backgroundColor: task.color,
-                        }}
-                      />
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -1,21 +1,21 @@
 :global(#app) {
   .wrapper {
+    display: flex;
     width: 100%;
   }
 
-  .column
-  {
+  .leftPane {
+    flex: 0 0 200px;
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    width: 100%;
+    background-color: #fff;
   }
 
-  .headerRow {
+  .rightPane {
+    flex: 1 1 0;
     display: flex;
-    font-weight: bold;
-    font-size: 12px;
-    width: 100%;
+    flex-direction: column;
+    min-width: 0;
   }
 
   .leftHeader {
@@ -59,22 +59,16 @@
   }
 
   .leftColumn {
-    flex: 0 0 200px;
-    background-color: #fff;
+    display: flex;
+    flex-direction: column;
   }
 
   .rightColumn {
     overflow-x: auto;
-    flex: 1 1 0;
+    flex: 1 1 auto;
     min-width: 0;
   }
 
-  .body {
-    display: flex;
-    align-items: flex-start;
-    width: 100%;
-    margin-top: -8px;
-  }
 
   .timeline {
     position: relative;

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -60,17 +60,13 @@
 
   .leftColumn {
     flex: 0 0 200px;
-    position: fixed;
-    width: 200px;
     background-color: #fff;
   }
 
   .rightColumn {
     overflow-x: auto;
-    position: relative;
-    flex: 1 1 0;
+    flex: 1 1 auto;
     min-width: 0;
-    margin-left: 200px;
   }
 
   .body {

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -1,25 +1,14 @@
 :global(#app) {
   .wrapper {
-    display: flex;
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    grid-template-rows: auto 1fr;
     width: 100%;
   }
 
-  .leftPane {
-    flex: 0 0 200px;
-    display: flex;
-    flex-direction: column;
-    background-color: #fff;
-  }
-
-  .rightPane {
-    flex: 1 1 0;
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-  }
-
   .leftHeader {
-    flex: 0 0 200px;
+    grid-column: 1;
+    grid-row: 1;
     display: flex;
     align-items: center;
     height: 48px;
@@ -27,8 +16,9 @@
   }
 
   .rightHeader {
+    grid-column: 2;
+    grid-row: 1;
     overflow-x: auto;
-    flex: 1 1 0;
     display: flex;
     flex-direction: column;
     min-width: 0;
@@ -59,13 +49,16 @@
   }
 
   .leftColumn {
+    grid-column: 1;
+    grid-row: 2;
     display: flex;
     flex-direction: column;
   }
 
   .rightColumn {
+    grid-column: 2;
+    grid-row: 2;
     overflow-x: auto;
-    flex: 1 1 auto;
     min-width: 0;
   }
 

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -65,7 +65,7 @@
 
   .rightColumn {
     overflow-x: auto;
-    flex: 1 1 auto;
+    flex: 1 1 0;
     min-width: 0;
   }
 


### PR DESCRIPTION
## Summary
- adjust Gantt layout so the timeline column scrolls horizontally without overflowing the page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c05fdb308323a5bcb2e1817c779a