### PR TITLE
Add epic titles within Gantt bars

### DIFF
--- a/client/src/components/common/Gantt/Gantt.jsx
+++ b/client/src/components/common/Gantt/Gantt.jsx
@@ -17,6 +17,16 @@ import styles from './Gantt.module.scss';
 const DAY_WIDTH = 32; // px width per day
 const ROW_HEIGHT = 32; // px height per task row
 
+const getTextColor = (hex) => {
+  if (!hex) return '#000';
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.substring(0, 2), 16);
+  const g = parseInt(clean.substring(2, 4), 16);
+  const b = parseInt(clean.substring(4, 6), 16);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 128 ? '#000' : '#fff';
+};
+
 const Gantt = React.memo(({ tasks, onChange, onEpicClick }) => {
   const { t } = useTranslation();
   const headerRef = useRef(null);
@@ -275,6 +285,12 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick }) => {
                       backgroundColor: task.color,
                     }}
                   >
+                    <div
+                      className={styles.label}
+                      style={{ color: getTextColor(task.color) }}
+                    >
+                      {task.name}
+                    </div>
                     {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
                     <div className={styles.gripLeft} onMouseDown={startResize(index, 'start')} />
                     {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -111,6 +111,7 @@
     white-space: nowrap;
     font-size: 10px;
     padding: 0 4px;
+    text-align: center;
   }
 
   .gripLeft,

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -112,6 +112,7 @@
     font-size: 10px;
     padding: 0 4px;
     text-align: center;
+    user-select: none;
   }
 
   .gripLeft,

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -97,9 +97,20 @@
 
   .bar {
     position: absolute;
+    display: flex;
+    align-items: center;
     height: 22px;
     top: 4px;
     border-radius: 5px ;
+    }
+
+  .label {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 10px;
+    padding: 0 4px;
   }
 
   .gripLeft,


### PR DESCRIPTION
## Summary
- show each epic title inside its Gantt bar
- truncate long titles
- adapt text color depending on bar color

## Testing
- `npm test` *(fails: jest not found for client)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5ca82f08323a98ef3e36eea152b