### PR TITLE
Add cards to Gantt view

### DIFF
--- a/client/src/components/common/Gantt/Gantt.jsx
+++ b/client/src/components/common/Gantt/Gantt.jsx
@@ -261,9 +261,11 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick }) => {
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
           <div
             key={task.id}
-            className={styles.epicRow}
+            className={task.isChild ? styles.cardRow : styles.epicRow}
             style={{ height: ROW_HEIGHT }}
-            onClick={onEpicClick ? () => onEpicClick(task.id) : undefined}
+            onClick={
+              !task.isChild && onEpicClick ? () => onEpicClick(task.id) : undefined
+            }
           >
             {task.name}
           </div>
@@ -274,7 +276,11 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick }) => {
           {localTasks.map((task, index) => {
             const bar = getBarStyle(task);
             return (
-              <div key={task.id} className={styles.row} style={{ height: ROW_HEIGHT }}>
+              <div
+                key={task.id}
+                className={task.isChild ? styles.cardRow : styles.row}
+                style={{ height: ROW_HEIGHT }}
+              >
                 {bar && (
                   // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                   <div
@@ -320,6 +326,7 @@ Gantt.propTypes = {
       startDate: PropTypes.instanceOf(Date),
       endDate: PropTypes.instanceOf(Date),
       progress: PropTypes.number,
+      isChild: PropTypes.bool,
     }),
   ).isRequired,
   // eslint-disable-next-line react/require-default-props

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -96,8 +96,15 @@
   }
 
   .cardRow {
-    composes: epicRow;
+    position: relative;
+    height: 24px;
+    line-height: 24px;
+    border-bottom: 1px solid #f0f0f0;
+    font-size: 12px;
     padding-left: 26px;
+    width: 200px;
+    background-color: #fff;
+    z-index: 100;
     cursor: default;
   }
 

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -95,6 +95,12 @@
     font-size: 12px;
   }
 
+  .cardRow {
+    composes: epicRow;
+    padding-left: 26px;
+    cursor: default;
+  }
+
   .bar {
     position: absolute;
     display: flex;

--- a/client/src/components/projects/ProjectEpics/ProjectEpics.jsx
+++ b/client/src/components/projects/ProjectEpics/ProjectEpics.jsx
@@ -20,11 +20,26 @@ const ProjectEpics = React.memo(() => {
     return ids.map((id) => selectors.selectEpicById(state, id));
   });
 
+  const boardIds = useSelector((state) =>
+    selectors.selectBoardIdsByProjectId(state, projectId) || [],
+  );
+  const boards = useSelector((state) =>
+    boardIds.map((id) => selectors.selectBoardById(state, id)),
+  );
+
   useEffect(() => {
     if (projectId) {
       dispatch(entryActions.fetchEpics(projectId));
     }
   }, [dispatch, projectId]);
+
+  useEffect(() => {
+    boards.forEach((board) => {
+      if (board && board.isFetching === null) {
+        dispatch(entryActions.fetchBoard(board.id));
+      }
+    });
+  }, [dispatch, boards]);
 
   const selectCardIdsByEpicId = useMemo(
     () => selectors.makeSelectCardIdsByEpicId(),

--- a/client/src/selectors/epics.js
+++ b/client/src/selectors/epics.js
@@ -29,9 +29,24 @@ export const makeSelectEpicIdsByProjectId = () =>
 
 export const selectEpicIdsByProjectId = makeSelectEpicIdsByProjectId();
 
+export const makeSelectCardIdsByEpicId = () =>
+  createSelector(
+    orm,
+    (_, epicId) => epicId,
+    ({ Epic }, epicId) => {
+      const model = Epic.withId(epicId);
+      if (!model) return [];
+      return model.cards.toRefArray().map((card) => card.id);
+    },
+  );
+
+export const selectCardIdsByEpicId = makeSelectCardIdsByEpicId();
+
 export default {
   makeSelectEpicById,
   selectEpicById,
   makeSelectEpicIdsByProjectId,
   selectEpicIdsByProjectId,
+  makeSelectCardIdsByEpicId,
+  selectCardIdsByEpicId,
 };


### PR DESCRIPTION
## Summary
- show epic cards in project Gantt diagram
- allow dragging card bars to update start/end dates
- automatically extend epic dates when a child card is moved

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752d1f5ae88323a147eeabaaa62db7