### PR TITLE
Display epic badge under card key

### DIFF
--- a/client/src/components/cards/Card/ProjectContent.jsx
+++ b/client/src/components/cards/Card/ProjectContent.jsx
@@ -22,6 +22,7 @@ import UserAvatar from '../../users/UserAvatar';
 import LabelChip from '../../labels/LabelChip';
 import CustomFieldValueChip from '../../custom-field-values/CustomFieldValueChip';
 import { CardTypeIcons } from '../../../constants/Icons';
+import EpicChip from '../../epics/EpicChip';
 
 import styles from './ProjectContent.module.scss';
 
@@ -182,6 +183,11 @@ const ProjectContent = React.memo(({ cardId }) => {
       {isTeamProject && (
         <div className={styles.cardKey}>
           {project.code}-{card.number}
+        </div>
+      )}
+      {card.epicId && project.useEpics && (
+        <div className={styles.epic}>
+          <EpicChip id={card.epicId} size="tiny" />
         </div>
       )}
       {coverUrl && (

--- a/client/src/components/cards/Card/ProjectContent.module.scss
+++ b/client/src/components/cards/Card/ProjectContent.module.scss
@@ -110,6 +110,11 @@
     margin-bottom: 4px;
   }
 
+  .epic {
+    margin-top: -2px;
+    margin-bottom: 4px;
+  }
+
   .notification {
     background: #eb5a46;
     color: #fff;

--- a/client/src/components/cards/Card/StoryContent.jsx
+++ b/client/src/components/cards/Card/StoryContent.jsx
@@ -15,6 +15,7 @@ import { BoardViews, ListTypes } from '../../../constants/Enums';
 import LabelChip from '../../labels/LabelChip';
 import CustomFieldValueChip from '../../custom-field-values/CustomFieldValueChip';
 import StoryPointsChip from '../StoryPointsChip';
+import EpicChip from '../../epics/EpicChip';
 
 import styles from './StoryContent.module.scss';
 
@@ -121,6 +122,11 @@ const StoryContent = React.memo(({ cardId }) => {
         {isTeamProject && (
           <div className={styles.cardKey}>
             {project.code}-{card.number}
+          </div>
+        )}
+        {card.epicId && project.useEpics && (
+          <div className={styles.epic}>
+            <EpicChip id={card.epicId} size="tiny" />
           </div>
         )}
         {card.description && <div className={styles.descriptionText}>{descriptionText}</div>}

--- a/client/src/components/cards/Card/StoryContent.module.scss
+++ b/client/src/components/cards/Card/StoryContent.module.scss
@@ -91,6 +91,11 @@
     margin-bottom: 4px;
   }
 
+  .epic {
+    margin-top: -2px;
+    margin-bottom: 4px;
+  }
+
   .storyPoints {
     flex-shrink: 0;
     margin-left: 4px;

--- a/client/src/components/epics/EpicChip/EpicChip.jsx
+++ b/client/src/components/epics/EpicChip/EpicChip.jsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useSelector } from 'react-redux';
+
+import selectors from '../../../selectors';
+import getTextColor from '../../../utils/get-text-color';
+
+import styles from './EpicChip.module.scss';
+
+const Sizes = {
+  TINY: 'tiny',
+  SMALL: 'small',
+  MEDIUM: 'medium',
+};
+
+const EpicChip = React.memo(({ id, size }) => {
+  const selectEpicById = useMemo(() => selectors.makeSelectEpicById(), []);
+  const epic = useSelector((state) => selectEpicById(state, id));
+
+  if (!epic) return null;
+
+  return (
+    <span
+      title={epic.name}
+      className={classNames(styles.wrapper, styles[`wrapper${size.charAt(0).toUpperCase() + size.slice(1)}`])}
+      style={{ background: epic.color || '#dce0e4', color: getTextColor(epic.color) }}
+    >
+      {epic.name}
+    </span>
+  );
+});
+
+EpicChip.propTypes = {
+  id: PropTypes.string.isRequired,
+  size: PropTypes.oneOf(Object.values(Sizes)),
+};
+
+EpicChip.defaultProps = {
+  size: Sizes.MEDIUM,
+};
+
+export default EpicChip;

--- a/client/src/components/epics/EpicChip/EpicChip.module.scss
+++ b/client/src/components/epics/EpicChip/EpicChip.module.scss
@@ -1,0 +1,28 @@
+:global(#app) {
+  .wrapper {
+    border-radius: 3px;
+    display: inline-block;
+    padding: 2px 6px;
+    font-size: 12px;
+    line-height: 20px;
+    white-space: nowrap;
+  }
+
+  .wrapperTiny {
+    font-size: 12px;
+    line-height: 20px;
+    padding: 0 6px;
+  }
+
+  .wrapperSmall {
+    font-size: 12px;
+    line-height: 20px;
+    padding: 2px 8px;
+  }
+
+  .wrapperMedium {
+    font-size: 14px;
+    line-height: 24px;
+    padding: 4px 12px;
+  }
+}

--- a/client/src/components/epics/EpicChip/index.js
+++ b/client/src/components/epics/EpicChip/index.js
@@ -1,0 +1,3 @@
+import EpicChip from './EpicChip';
+
+export default EpicChip;

--- a/client/src/utils/get-text-color.js
+++ b/client/src/utils/get-text-color.js
@@ -1,0 +1,9 @@
+export default function getTextColor(hex) {
+  if (!hex) return '#000';
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.substring(0, 2), 16);
+  const g = parseInt(clean.substring(2, 4), 16);
+  const b = parseInt(clean.substring(4, 6), 16);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 128 ? '#000' : '#fff';
+}


### PR DESCRIPTION
## Summary
- add `EpicChip` component to render the epic name in its color
- add `getTextColor` helper for good contrast
- show epic badge on cards when an epic is assigned

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754dd710288323ad106397eb59fff2