### PR TITLE
Add button to clear epic icon

### DIFF
--- a/client/src/components/projects/EpicEditor/EpicEditor.jsx
+++ b/client/src/components/projects/EpicEditor/EpicEditor.jsx
@@ -2,11 +2,12 @@ import React, { useEffect, useImperativeHandle, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import DatePicker from 'react-datepicker';
-import { TextArea, Dropdown, Icon } from 'semantic-ui-react';
+import { TextArea, Dropdown, Icon, Button } from 'semantic-ui-react';
 import TextareaAutosize from 'react-textarea-autosize';
 import { Input } from '../../../lib/custom-ui';
 import ICON_OPTIONS from '../../../constants/CardTypeIconOptions';
 import styles from './EpicEditor.module.scss';
+import classNames from 'classnames';
 import { useNestedRef } from '../../../hooks';
 
 const EpicEditor = React.forwardRef(({ data, onFieldChange }, ref) => {
@@ -42,27 +43,39 @@ const EpicEditor = React.forwardRef(({ data, onFieldChange }, ref) => {
         onChange={onFieldChange}
       />
       <div>{t('common.icon')}</div>
-      <Dropdown
-        fluid
-        selection
-        search
-        name="icon"
-        value={data.icon}
-        options={ICON_OPTIONS.map((icon) => ({
-          key: icon,
-          text: icon,
-          value: icon,
-          content: (
-            <span>
-              <Icon name={icon} /> {icon}
-            </span>
-          ),
-        }))}
-        className={styles.field}
-        onChange={(_, { value }) =>
-          onFieldChange(undefined, { name: 'icon', value })
-        }
-      />
+      <div className={styles.iconWrapper}>
+        <Button
+          type="button"
+          icon="close"
+          title={t('action.remove')}
+          disabled={!data.icon}
+          className={styles.clearIconButton}
+          onClick={() =>
+            onFieldChange(undefined, { name: 'icon', value: '' })
+          }
+        />
+        <Dropdown
+          fluid
+          selection
+          search
+          name="icon"
+          value={data.icon}
+          options={ICON_OPTIONS.map((icon) => ({
+            key: icon,
+            text: icon,
+            value: icon,
+            content: (
+              <span>
+                <Icon name={icon} /> {icon}
+              </span>
+            ),
+          }))}
+          className={classNames(styles.field, styles.iconDropdown)}
+          onChange={(_, { value }) =>
+            onFieldChange(undefined, { name: 'icon', value })
+          }
+        />
+      </div>
       <div>{t('common.color')}</div>
       <input
         type="color"

--- a/client/src/components/projects/EpicEditor/EpicEditor.module.scss
+++ b/client/src/components/projects/EpicEditor/EpicEditor.module.scss
@@ -11,4 +11,28 @@
     padding: 0;
     border: none;
   }
+
+  .iconWrapper {
+    display: flex;
+    margin-bottom: 8px;
+  }
+
+  .clearIconButton {
+    background: transparent;
+    box-shadow: none;
+    margin: 0;
+    width: 36px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    &:hover {
+      background: #e9e9e9;
+    }
+  }
+
+  .iconDropdown {
+    flex: 1 1 auto;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- add a clear button to the epic editor icon field
- style icon field with wrapper, dropdown and clear button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f02119e0832388512d3330994e6d