### PR TITLE
Display epic icons in Gantt

### DIFF
--- a/client/src/components/common/Gantt/Gantt.jsx
+++ b/client/src/components/common/Gantt/Gantt.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef, useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { Icon } from 'semantic-ui-react';
 import {
   differenceInCalendarDays,
   addMonths,
@@ -363,6 +364,9 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick, onReorder }) => {
                               : undefined
                           }
                         >
+                          {group.epic.icon && (
+                            <Icon name={group.epic.icon} className={styles.icon} />
+                          )}
                           {group.epic.name}
                         </div>
                         {group.children.map((task) => (
@@ -411,6 +415,9 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick, onReorder }) => {
                     }}
                   >
                     <div className={styles.label} style={{ color: getTextColor(task.color) }}>
+                      {!task.isChild && task.icon && (
+                        <Icon name={task.icon} className={styles.icon} />
+                      )}
                       {task.name}
                     </div>
                     {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
@@ -441,6 +448,7 @@ Gantt.propTypes = {
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
       name: PropTypes.string.isRequired,
       color: PropTypes.string,
+      icon: PropTypes.string,
       startDate: PropTypes.instanceOf(Date),
       endDate: PropTypes.instanceOf(Date),
       progress: PropTypes.number,

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -164,4 +164,8 @@
     height: 100%;
     opacity: 0.3;
   }
+
+  .icon {
+    margin-right: 4px;
+  }
 }

--- a/client/src/components/projects/ProjectEpics/ProjectEpics.jsx
+++ b/client/src/components/projects/ProjectEpics/ProjectEpics.jsx
@@ -51,6 +51,7 @@ const ProjectEpics = React.memo(() => {
       result.push({
         id: `epic-${e.id}`,
         name: e.name,
+        icon: e.icon,
         color: e.color,
         startDate: e.startDate ? new Date(e.startDate) : null,
         endDate: e.endDate ? new Date(e.endDate) : null,


### PR DESCRIPTION
## Summary
- include epic icon in generated Gantt task data
- render epic icon in Gantt rows and bars
- style icons in Gantt view

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f5eea2dc83238c0523ad6b411c8a