### PR TITLE
Change header branding

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="PLANKA is the kanban-style project mastering tool for everyone" />
-    <title>PLANKA</title>
+    <meta name="description" content="Kanav is the kanban-style project mastering tool for everyone" />
+    <title>Kanav</title>
     <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />

--- a/client/src/components/common/Header/Header.jsx
+++ b/client/src/components/common/Header/Header.jsx
@@ -94,11 +94,11 @@ const Header = React.memo(() => {
 
   return (
     <div className={styles.wrapper}>
-      {!project && (
-        <Link to={Paths.ROOT} className={classNames(styles.logo, styles.title)}>
-          PLANKA
-        </Link>
-      )}
+        {!project && (
+          <Link to={Paths.ROOT} className={classNames(styles.logo, styles.title)}>
+            Kanav
+          </Link>
+        )}
       <Menu inverted size="large" className={styles.menu}>
         {project && (
           <Menu.Menu position="left">


### PR DESCRIPTION
## Summary
- tweak the HTML title and description to use Kanav branding
- update the header component text from 'PLANKA' to 'Kanav'

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763f26c2308323bf472979e1e83ef4