### PR TITLE
Mark completed tasks grey in Gantt

### DIFF
--- a/client/src/components/common/Gantt/Gantt.jsx
+++ b/client/src/components/common/Gantt/Gantt.jsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useCallback,
 } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
@@ -425,7 +426,10 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick, onReorder }) => {
                           group.children.map((task) => (
                             <div
                               key={task.id}
-                              className={styles.cardRow}
+                              className={classNames(
+                                styles.cardRow,
+                                task.isDone && styles.taskDone,
+                              )}
                               style={{ height: ROW_HEIGHT }}
                             >
                               {task.name}
@@ -448,13 +452,19 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick, onReorder }) => {
             return (
               <div
                 key={task.id}
-                className={task.isChild ? styles.cardRow : styles.row}
+                className={classNames(
+                  task.isChild ? styles.cardRow : styles.row,
+                  task.isDone && styles.taskDone,
+                )}
                 style={{ height: ROW_HEIGHT }}
               >
                 {bar && (
                   // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                   <div
-                    className={task.isChild ? styles.barTask : styles.bar}
+                    className={classNames(
+                      task.isChild ? styles.barTask : styles.bar,
+                      task.isDone && styles.barDone,
+                    )}
                     onMouseDown={startDrag(index)}
                     onDoubleClick={
                       !task.isChild && onEpicClick
@@ -464,10 +474,13 @@ const Gantt = React.memo(({ tasks, onChange, onEpicClick, onReorder }) => {
                     style={{
                       left: bar.offset,
                       width: bar.width,
-                      backgroundColor: task.color,
+                      backgroundColor: task.isDone ? '#ccc' : task.color,
                     }}
                   >
-                    <div className={styles.label} style={{ color: getTextColor(task.color) }}>
+                    <div
+                      className={styles.label}
+                      style={{ color: getTextColor(task.isDone ? '#ccc' : task.color) }}
+                    >
                       {!task.isChild && task.icon && (
                         <Icon name={task.icon} className={styles.icon} />
                       )}

--- a/client/src/components/common/Gantt/Gantt.module.scss
+++ b/client/src/components/common/Gantt/Gantt.module.scss
@@ -130,6 +130,11 @@
     user-select: none;
   }
 
+  .taskDone {
+    color: #aaa;
+    text-decoration: line-through;
+  }
+
   .bar {
     position: absolute;
     display: flex;
@@ -149,6 +154,10 @@
     opacity: 0.75;
     border-radius: 5px ;
     cursor: pointer;
+  }
+
+  .barDone {
+    background-color: #ccc !important;
   }
 
   .label {

--- a/client/src/components/projects/ProjectEpics/ProjectEpics.jsx
+++ b/client/src/components/projects/ProjectEpics/ProjectEpics.jsx
@@ -7,6 +7,7 @@ import entryActions from '../../../entry-actions';
 import AddEpicModal from '../AddEpicModal';
 import EditEpicModal from '../EditEpicModal';
 import Gantt from '../../common/Gantt';
+import { ListTypes } from '../../../constants/Enums';
 import Styles from './ProjectEpics.module.scss';
 
 const ProjectEpics = React.memo(() => {
@@ -43,6 +44,7 @@ const ProjectEpics = React.memo(() => {
 
   const selectCardIdsByEpicId = useMemo(() => selectors.makeSelectCardIdsByEpicId(), []);
   const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
+  const selectListById = useMemo(() => selectors.makeSelectListById(), []);
 
   const { tasks, epicMap } = useSelector((state) => {
     const result = [];
@@ -60,6 +62,8 @@ const ProjectEpics = React.memo(() => {
       const cardIds = selectCardIdsByEpicId(state, e.id) || [];
       cardIds.forEach((cardId) => {
         const card = selectCardById(state, cardId);
+        const list = selectListById(state, card.listId);
+        const isDone = list && list.type === ListTypes.CLOSED;
         result.push({
           id: `card-${card.id}`,
           name: card.name,
@@ -78,6 +82,7 @@ const ProjectEpics = React.memo(() => {
               : null,
           progress: 0,
           isChild: true,
+          isDone,
         });
         map[`card-${card.id}`] = e.id;
       });


### PR DESCRIPTION
## Summary
- support showing closed cards in Gantt
- add grey/strikethrough styles for done tasks

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: integrity checksum error)*

------
https://chatgpt.com/codex/tasks/task_e_6877ffd0b0d48323b488e4582c8c39c2