### PR TITLE
Avoid null admin name during seed

### DIFF
--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -10,11 +10,7 @@ const buildData = (email) => {
     role: 'admin',
     isSsoUser: false,
     isDeactivated: false,
-    name:
-      process.env.DEFAULT_ADMIN_NAME ||
-      process.env.DEFAULT_ADMIN_USERNAME ||
-      email ||
-      'Admin',
+    name: process.env.DEFAULT_ADMIN_NAME || process.env.DEFAULT_ADMIN_USERNAME || email || 'Admin',
   };
 
   if (process.env.DEFAULT_ADMIN_PASSWORD) {

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -5,19 +5,22 @@
 
 const bcrypt = require('bcrypt');
 
-const buildData = () => {
+const buildData = (email) => {
   const data = {
     role: 'admin',
     isSsoUser: false,
     isDeactivated: false,
+    name:
+      process.env.DEFAULT_ADMIN_NAME ||
+      process.env.DEFAULT_ADMIN_USERNAME ||
+      email ||
+      'Admin',
   };
 
   if (process.env.DEFAULT_ADMIN_PASSWORD) {
     data.password = bcrypt.hashSync(process.env.DEFAULT_ADMIN_PASSWORD, 10);
   }
-  if (process.env.DEFAULT_ADMIN_NAME) {
-    data.name = process.env.DEFAULT_ADMIN_NAME;
-  }
+
   if (process.env.DEFAULT_ADMIN_USERNAME) {
     data.username = process.env.DEFAULT_ADMIN_USERNAME.toLowerCase();
   }
@@ -29,7 +32,7 @@ exports.seed = async (knex) => {
   const email = process.env.DEFAULT_ADMIN_EMAIL && process.env.DEFAULT_ADMIN_EMAIL.toLowerCase();
 
   if (email) {
-    const data = buildData();
+    const data = buildData(email);
 
     let userId;
     try {


### PR DESCRIPTION
## Summary
- ensure admin seeding always provides a name using env vars or fallback

## Testing
- `npm test --prefix server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68c3db062118832382bc659c18be1b08