### PR TITLE
Fix duplicate admin seeding by checking existing user

### DIFF
--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -29,10 +29,15 @@ exports.seed = async (knex) => {
 
   if (email) {
     const data = buildData(email);
+    const existingUser = await knex('user_account')
+      .select('id')
+      .where({ email })
+      .first();
 
-    let userId;
-    try {
-      [{ id: userId }] = await knex('user_account').insert(
+    if (existingUser) {
+      await knex('user_account').update(data).where('id', existingUser.id);
+    } else {
+      await knex('user_account').insert(
         {
           ...data,
           email,
@@ -47,12 +52,6 @@ exports.seed = async (knex) => {
         },
         'id',
       );
-    } catch (error) {
-      /* empty */
-    }
-
-    if (!userId) {
-      await knex('user_account').update(data).where('email', email);
     }
   }
 

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -29,10 +29,7 @@ exports.seed = async (knex) => {
 
   if (email) {
     const data = buildData(email);
-    const existingUser = await knex('user_account')
-      .select('id')
-      .where({ email })
-      .first();
+    const existingUser = await knex('user_account').select('id').where({ email }).first();
 
     if (existingUser) {
       await knex('user_account').update(data).where('id', existingUser.id);


### PR DESCRIPTION
## Summary
- avoid duplicate key errors when seeding admin user
- look up existing admin email before insert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7ad34d65c83238004f4167816e71c