### PR TITLE
chore: switch Docker images to Debian base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:22-alpine AS server-dependencies
+FROM node:22-bookworm-slim AS server-dependencies
 
-RUN apk -U upgrade \
-  && apk add build-base python3 --no-cache
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y build-essential python3 \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -21,10 +23,12 @@ RUN npm install npm --global \
 
 RUN DISABLE_ESLINT_PLUGIN=true npm run build
 
-FROM node:22-alpine
+FROM node:22-bookworm-slim
 
-RUN apk -U upgrade \
-  && apk add bash python3 --no-cache \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y bash python3 python3-venv \
+  && rm -rf /var/lib/apt/lists/* \
   && npm install npm --global
 
 USER node

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,9 @@
-FROM node:22-alpine
+FROM node:22-bookworm-slim
 
-RUN apk -U upgrade \
-  && apk add bash build-base python3 xdg-utils --no-cache \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y bash build-essential python3 xdg-utils \
+  && rm -rf /var/lib/apt/lists/* \
   && npm install npm --global
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- use `node:22-bookworm-slim` instead of Alpine images
- install build deps via `apt-get` and clean cache

## Testing
- `docker build -t planka-debian .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `docker run -p 1337:1337 planka-debian` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d1037210832397831416d1ef6d28