### PR TITLE
fix(docker): install python venv for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-bookworm-slim AS server-dependencies
 
 RUN apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y build-essential python3 \
+  && apt-get install -y build-essential python3 python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM node:22-bookworm-slim
 
 RUN apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y bash build-essential python3 xdg-utils \
+  && apt-get install -y bash build-essential python3 python3-venv xdg-utils \
   && rm -rf /var/lib/apt/lists/* \
   && npm install npm --global
 


### PR DESCRIPTION
## Summary
- install python3-venv in Docker build and dev images to enable Python virtualenv creation

## Testing
- `npm test --prefix server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68c7d364e84c83239373bfd71c937778