### PR TITLE
Add OIDC logout redirect with id token hint

### DIFF
--- a/server/api/controllers/access-tokens/exchange-with-oidc.js
+++ b/server/api/controllers/access-tokens/exchange-with-oidc.js
@@ -76,7 +76,7 @@ module.exports = {
   async fn(inputs) {
     const remoteAddress = getRemoteAddress(this.req);
 
-    const user = await sails.helpers.users
+    const { user, idToken } = await sails.helpers.users
       .getOrCreateOneWithOidc(inputs.code, inputs.nonce)
       .intercept('invalidOidcConfiguration', () => Errors.INVALID_OIDC_CONFIGURATION)
       .intercept('invalidCodeOrNonce', () => {
@@ -101,6 +101,7 @@ module.exports = {
       remoteAddress,
       userId: user.id,
       userAgent: this.req.headers['user-agent'],
+      oidcIdToken: idToken,
     });
 
     if (httpOnlyToken && !this.req.isSocket) {

--- a/server/api/controllers/config/show.js
+++ b/server/api/controllers/config/show.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   async fn() {
-    const { currentUser } = this.req;
+    const { currentUser, currentSession } = this.req;
 
     const oidcClient = await sails.hooks.oidc.getClient();
 
@@ -21,7 +21,14 @@ module.exports = {
 
       oidc = {
         authorizationUrl: oidcClient.authorizationUrl(authorizationUrlParams),
-        endSessionUrl: oidcClient.issuer.end_session_endpoint ? oidcClient.endSessionUrl({}) : null,
+        endSessionUrl: oidcClient.issuer.end_session_endpoint
+          ? oidcClient.endSessionUrl({
+              post_logout_redirect_uri: `${sails.config.custom.baseUrl}/login`,
+              ...(currentSession && currentSession.oidcIdToken
+                ? { id_token_hint: currentSession.oidcIdToken }
+                : {}),
+            })
+          : null,
         isEnforced: sails.config.custom.oidcEnforced,
       };
     }

--- a/server/api/helpers/users/get-or-create-one-with-oidc.js
+++ b/server/api/helpers/users/get-or-create-one-with-oidc.js
@@ -182,6 +182,6 @@ module.exports = {
       }
     }
 
-    return user;
+    return { user, idToken: tokenSet.id_token };
   },
 };

--- a/server/api/models/Session.js
+++ b/server/api/models/Session.js
@@ -27,6 +27,12 @@ module.exports = {
       allowNull: true,
       columnName: 'http_only_token',
     },
+    oidcIdToken: {
+      type: 'string',
+      isNotEmptyString: true,
+      allowNull: true,
+      columnName: 'oidc_id_token',
+    },
     remoteAddress: {
       type: 'string',
       required: true,


### PR DESCRIPTION
## Summary
- persist OIDC `id_token` in sessions for logout
- send `post_logout_redirect_uri` and optional `id_token_hint` when building end session URL

## Testing
- `npm run server:lint`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68c801d48c5c832380f50fff9964f605