### PR TITLE
Add migration for OIDC ID token in sessions

### DIFF
--- a/server/db/migrations/20250917120000_add_oidc_id_token_to_session.js
+++ b/server/db/migrations/20250917120000_add_oidc_id_token_to_session.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.table('session', (table) => {
+    table.text('oidc_id_token');
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('session', (table) => {
+    table.dropColumn('oidc_id_token');
+  });
+};


### PR DESCRIPTION
## Summary
- add migration creating `oidc_id_token` column in `session` table

## Testing
- `npm test --prefix server`
- `npm run lint --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_68c8056ef2408323be4d194f7c102a6d