### PR TITLE
feat: log OIDC exchange details and sessions

### DIFF
--- a/server/api/controllers/access-tokens/exchange-with-oidc.js
+++ b/server/api/controllers/access-tokens/exchange-with-oidc.js
@@ -76,6 +76,10 @@ module.exports = {
   async fn(inputs) {
     const remoteAddress = getRemoteAddress(this.req);
 
+    sails.log.debug(
+      `OIDC exchange attempt (IP: ${remoteAddress}, code length: ${inputs.code.length}, nonce length: ${inputs.nonce.length})`,
+    );
+
     const { user, idToken } = await sails.helpers.users
       .getOrCreateOneWithOidc(inputs.code, inputs.nonce)
       .intercept('invalidOidcConfiguration', () => Errors.INVALID_OIDC_CONFIGURATION)
@@ -103,6 +107,10 @@ module.exports = {
       userAgent: this.req.headers['user-agent'],
       oidcIdToken: idToken,
     });
+
+    sails.log.info(
+      `OIDC session created (userId: ${user.id}, IP: ${remoteAddress}, userAgent: ${this.req.headers['user-agent']})`,
+    );
 
     if (httpOnlyToken && !this.req.isSocket) {
       sails.helpers.utils.setHttpOnlyTokenCookie(httpOnlyToken, accessTokenPayload, this.res);


### PR DESCRIPTION
## Summary
- add debug logging for OIDC exchange attempts including IP and parameter lengths
- log user ID, IP, and user agent after OIDC session creation

## Testing
- `npm test --prefix server`
- `npm test --prefix client`
- `npm run server:lint`
- `npm run client:lint`


------
https://chatgpt.com/codex/tasks/task_e_68c809cea4d88323ad6b431644a53aa0