### PR TITLE
Add personal project owner role

### DIFF
--- a/client/src/constants/Enums.js
+++ b/client/src/constants/Enums.js
@@ -21,6 +21,7 @@ export const HomeViews = {
 export const UserRoles = {
   ADMIN: 'admin',
   PROJECT_OWNER: 'projectOwner',
+  PERSONAL_PROJECT_OWNER: 'personalProjectOwner',
   BOARD_USER: 'boardUser',
 };
 

--- a/client/src/constants/Icons.js
+++ b/client/src/constants/Icons.js
@@ -24,6 +24,7 @@ export const HomeViewIcons = {
 export const UserRoleIcons = {
   [UserRoles.ADMIN]: 'user secret',
   [UserRoles.PROJECT_OWNER]: 'building',
+  [UserRoles.PERSONAL_PROJECT_OWNER]: 'user',
   [UserRoles.BOARD_USER]: 'columns',
 };
 

--- a/server/api/models/User.js
+++ b/server/api/models/User.js
@@ -13,6 +13,7 @@
 const Roles = {
   ADMIN: 'admin',
   PROJECT_OWNER: 'projectOwner',
+  PERSONAL_PROJECT_OWNER: 'personalProjectOwner',
   BOARD_USER: 'boardUser',
 };
 


### PR DESCRIPTION
## Summary
- add the personal project owner role constant to the user model and validation
- expose the new role on the client enums and map it to an icon

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8f743f3748323b1d0902efa24ca79