### PR TITLE
Add personal project owner role option

### DIFF
--- a/client/src/components/common/AdministrationModal/UsersPane/AddStep.jsx
+++ b/client/src/components/common/AdministrationModal/UsersPane/AddStep.jsx
@@ -63,8 +63,8 @@ const AddStep = React.memo(({ onClose }) => {
     password: '',
     name: '',
     username: '',
-    role: UserRoles.BOARD_USER,
     ...defaultData,
+    role: defaultData?.role ?? UserRoles.BOARD_USER,
   }));
 
   const [step, openStep, handleBack] = useSteps();
@@ -81,6 +81,7 @@ const AddStep = React.memo(({ onClose }) => {
       email: data.email.trim(),
       name: data.name.trim(),
       username: data.username.trim() || null,
+      role: data.role,
     };
 
     if (!isEmail(cleanData.email)) {

--- a/client/src/components/common/AdministrationModal/UsersPane/SelectRoleStep.jsx
+++ b/client/src/components/common/AdministrationModal/UsersPane/SelectRoleStep.jsx
@@ -17,6 +17,7 @@ import styles from './SelectRoleStep.module.scss';
 const DESCRIPTION_BY_ROLE = {
   [UserRoles.ADMIN]: 'common.canManageSystemWideSettingsAndActAsProjectOwner',
   [UserRoles.PROJECT_OWNER]: 'common.canCreateOwnProjectsAndBeInvitedToWorkInOthers',
+  [UserRoles.PERSONAL_PROJECT_OWNER]: 'common.canCreatePersonalProjectsOnly',
   [UserRoles.BOARD_USER]: 'common.canBeInvitedToWorkInBoards',
 };
 
@@ -58,7 +59,12 @@ const SelectRoleStep = React.memo(
         <Popup.Content>
           <Form onSubmit={handleSubmit}>
             <Menu secondary vertical className={styles.menu}>
-              {[UserRoles.ADMIN, UserRoles.PROJECT_OWNER, UserRoles.BOARD_USER].map((role) => (
+              {[
+                UserRoles.ADMIN,
+                UserRoles.PROJECT_OWNER,
+                UserRoles.PERSONAL_PROJECT_OWNER,
+                UserRoles.BOARD_USER,
+              ].map((role) => (
                 <Menu.Item
                   key={role}
                   value={role}


### PR DESCRIPTION
## Summary
- surface the personal project owner role alongside other role choices in the administration modal
- keep the selected role value when creating a user so it is included in the submit payload

## Testing
- npm run client:lint

------
https://chatgpt.com/codex/tasks/task_e_68c8f861a5a0832393843da8318b7fe9