### PR TITLE
Add helper for project creation permissions

### DIFF
--- a/client/src/components/common/Home/GroupedProjectsView.jsx
+++ b/client/src/components/common/Home/GroupedProjectsView.jsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import selectors from '../../../selectors';
 import entryActions from '../../../entry-actions';
-import { isUserAdminOrProjectOwner } from '../../../utils/record-helpers';
+import { canUserCreateProject } from '../../../utils/record-helpers';
 import { ProjectGroups, ProjectTypes } from '../../../constants/Enums';
 import { ProjectGroupIcons } from '../../../constants/Icons';
 import Projects from './Projects';
@@ -30,7 +30,7 @@ const GroupedProjectsView = React.memo(() => {
 
   const canAdd = useSelector((state) => {
     const user = selectors.selectCurrentUser(state);
-    return isUserAdminOrProjectOwner(user);
+    return canUserCreateProject(user);
   });
 
   const dispatch = useDispatch();

--- a/client/src/components/common/Home/Projects.jsx
+++ b/client/src/components/common/Home/Projects.jsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { Grid, Icon } from 'semantic-ui-react';
 
 import selectors from '../../../selectors';
-import { isUserAdminOrProjectOwner } from '../../../utils/record-helpers';
+import { canUserCreateProject } from '../../../utils/record-helpers';
 import ProjectCard from '../../projects/ProjectCard';
 import PlusIcon from '../../../assets/images/plus-icon.svg?react';
 
@@ -20,7 +20,7 @@ import styles from './Projects.module.scss';
 const Projects = React.memo(({ ids, title, titleIcon, withTypeIndicator, onAdd }) => {
   const canAdd = useSelector((state) => {
     const user = selectors.selectCurrentUser(state);
-    return isUserAdminOrProjectOwner(user);
+    return canUserCreateProject(user);
   });
 
   const [t] = useTranslation();

--- a/client/src/selectors/modals.js
+++ b/client/src/selectors/modals.js
@@ -8,7 +8,7 @@ import { createSelector } from 'redux-orm';
 import orm from '../orm';
 import { selectPath } from './router';
 import { selectCurrentUserId } from './users';
-import { isUserAdminOrProjectOwner } from '../utils/record-helpers';
+import { canUserCreateProject } from '../utils/record-helpers';
 import ModalTypes from '../constants/ModalTypes';
 import { UserRoles } from '../constants/Enums';
 
@@ -27,7 +27,7 @@ export const isCurrentModalAvailableForCurrentUser = createSelector(
         case ModalTypes.ADMINISTRATION:
           return currentUserModel.role === UserRoles.ADMIN;
         case ModalTypes.ADD_PROJECT:
-          return isUserAdminOrProjectOwner(currentUserModel);
+          return canUserCreateProject(currentUserModel);
         case ModalTypes.PROJECT_SETTINGS: {
           const projectModel = Project.withId(currentProjectId);
           return !!projectModel && projectModel.isExternalAccessibleForUser(currentUserModel);

--- a/client/src/utils/record-helpers.js
+++ b/client/src/utils/record-helpers.js
@@ -8,6 +8,11 @@ import { ListTypes, UserRoles } from '../constants/Enums';
 export const isUserAdminOrProjectOwner = (user) =>
   [UserRoles.ADMIN, UserRoles.PROJECT_OWNER].includes(user.role);
 
+export const canUserCreateProject = (user) =>
+  [UserRoles.ADMIN, UserRoles.PROJECT_OWNER, UserRoles.PERSONAL_PROJECT_OWNER].includes(
+    user.role,
+  );
+
 export const isListArchiveOrTrash = (list) =>
   [ListTypes.ARCHIVE, ListTypes.TRASH].includes(list.type);
 

--- a/client/src/utils/record-helpers.js
+++ b/client/src/utils/record-helpers.js
@@ -9,9 +9,7 @@ export const isUserAdminOrProjectOwner = (user) =>
   [UserRoles.ADMIN, UserRoles.PROJECT_OWNER].includes(user.role);
 
 export const canUserCreateProject = (user) =>
-  [UserRoles.ADMIN, UserRoles.PROJECT_OWNER, UserRoles.PERSONAL_PROJECT_OWNER].includes(
-    user.role,
-  );
+  [UserRoles.ADMIN, UserRoles.PROJECT_OWNER, UserRoles.PERSONAL_PROJECT_OWNER].includes(user.role);
 
 export const isListArchiveOrTrash = (list) =>
   [ListTypes.ARCHIVE, ListTypes.TRASH].includes(list.type);

--- a/client/tests/record-helpers.test.js
+++ b/client/tests/record-helpers.test.js
@@ -1,10 +1,23 @@
-import { isUserAdminOrProjectOwner, isListArchiveOrTrash, isListFinite } from '../src/utils/record-helpers';
+import {
+  isUserAdminOrProjectOwner,
+  canUserCreateProject,
+  isListArchiveOrTrash,
+  isListFinite,
+} from '../src/utils/record-helpers';
 import { UserRoles, ListTypes } from '../src/constants/Enums';
 
 describe('record helpers', () => {
   test('isUserAdminOrProjectOwner', () => {
     expect(isUserAdminOrProjectOwner({ role: UserRoles.ADMIN })).toBe(true);
+    expect(isUserAdminOrProjectOwner({ role: UserRoles.PERSONAL_PROJECT_OWNER })).toBe(false);
     expect(isUserAdminOrProjectOwner({ role: UserRoles.BOARD_USER })).toBe(false);
+  });
+
+  test('canUserCreateProject', () => {
+    expect(canUserCreateProject({ role: UserRoles.ADMIN })).toBe(true);
+    expect(canUserCreateProject({ role: UserRoles.PROJECT_OWNER })).toBe(true);
+    expect(canUserCreateProject({ role: UserRoles.PERSONAL_PROJECT_OWNER })).toBe(true);
+    expect(canUserCreateProject({ role: UserRoles.BOARD_USER })).toBe(false);
   });
 
   test('isListArchiveOrTrash', () => {


### PR DESCRIPTION
## Summary
- add a canUserCreateProject helper that allows admins, project owners, and personal project owners to create projects
- use the new helper when checking project creation availability in home views and modal selectors
- extend record helper tests to cover project creation permissions and ensure the personal project owner role is not treated as a full project owner

## Testing
- npm run client:test -- record-helpers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9075b56348323a24f6a2636b0c670