### PR TITLE
Allow personal project owners to create projects

### DIFF
--- a/server/api/helpers/users/is-admin-or-project-owner.js
+++ b/server/api/helpers/users/is-admin-or-project-owner.js
@@ -3,6 +3,12 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
+const PROJECT_CREATION_ROLES = new Set([
+  User.Roles.ADMIN,
+  User.Roles.PROJECT_OWNER,
+  User.Roles.PERSONAL_PROJECT_OWNER,
+]);
+
 module.exports = {
   sync: true,
 
@@ -14,6 +20,6 @@ module.exports = {
   },
 
   fn(inputs) {
-    return [User.Roles.ADMIN, User.Roles.PROJECT_OWNER].includes(inputs.record.role);
+    return PROJECT_CREATION_ROLES.has(inputs.record.role);
   },
 };

--- a/server/api/policies/is-admin-or-project-owner.js
+++ b/server/api/policies/is-admin-or-project-owner.js
@@ -3,8 +3,10 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
-module.exports = async function isAuthenticated(req, res, proceed) {
-  if (!sails.helpers.users.isAdminOrProjectOwner(req.currentUser)) {
+const canUserCreateProjects = sails.helpers.users.isAdminOrProjectOwner;
+
+module.exports = async function canCreateProjects(req, res, proceed) {
+  if (!canUserCreateProjects(req.currentUser)) {
     return res.notFound(); // Forbidden
   }
 

--- a/server/config/policies.js
+++ b/server/config/policies.js
@@ -37,7 +37,11 @@ module.exports.policies = {
   'users/update-avatar': 'is-authenticated',
   'users/delete': ['is-authenticated', 'is-admin'],
 
-  'projects/create': ['is-authenticated', 'is-external', 'is-admin-or-project-owner'],
+  'projects/create': [
+    'is-authenticated',
+    'is-external',
+    'is-admin-or-project-owner', // Allows admins, project owners, and personal project owners.
+  ],
 
   'config/show': true,
   'access-tokens/create': true,


### PR DESCRIPTION
## Summary
- include the personal project owner role in the helper that backs the project creation policy
- call the helper through a dedicated alias in the policy and document the accepted roles in the policy map

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c92b16d8988323a79c5419e054427a