### PR TITLE
Document personal project owner role and expose Helm settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 - **Multilingual & Easy to Translate**: Full internationalization support for a global audience
 - **Stable List Slugs**: Lists have optional `slug` identifiers for reliable API queries, unaffected by renaming
 
+## Personal Project Owners
+
+Planka now includes a dedicated **personal project owner** role that gives users the ability to create and manage their own private projects without granting them global administration rights. Personal project owners are limited to two personal projects each by default. You can customize this cap with the `PERSONNAL_PROJECT_OWNER_LIMIT` environment variable (set it to `0` to disallow new personal projects entirely). If you provision users through OpenID Connect, map identity-provider groups to the role with the comma-separated `OIDC_PERSONNAL_PROJECT_OWNER_ROLES` environment variable.
+
 ## How to Deploy
 
 PLANKA is easy to install using multiple methods - learn more in the [installation guide](https://docs.planka.cloud/docs/welcome/).

--- a/charts/planka/README.md
+++ b/charts/planka/README.md
@@ -100,6 +100,20 @@ ingress:
 helm install planka . -f values.yaml
 ```
 
+### Personal project owners
+
+Planka's personal project owner role lets designated users maintain their own private projects while keeping shared workspaces under tighter control. The application allows two personal projects per user by default. Override the limit with the chart's `personalProjectOwnerLimit` value, which sets the `PERSONNAL_PROJECT_OWNER_LIMIT` environment variable inside the pod. When using OpenID Connect, map identity-provider groups to the role through `oidc.personalProjectOwner.roles` (this populates `OIDC_PERSONNAL_PROJECT_OWNER_ROLES`).
+
+```yaml
+personalProjectOwnerLimit: 4
+
+oidc:
+  enabled: true
+  personalProjectOwner:
+    roles:
+      - personnal_project_owner
+```
+
 ### Things to consider if production hosting
 
 If you want to host PLANKA for more than just playing around with, you might want to do the following things:

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -146,6 +146,11 @@ spec:
             - name: DEFAULT_ADMIN_PASSWORD
               value: {{ .Values.admin_password }}
             {{- end }}
+            {{- $personalProjectOwnerLimitValue := toString .Values.personalProjectOwnerLimit }}
+            {{- if ne $personalProjectOwnerLimitValue "" }}
+            - name: PERSONNAL_PROJECT_OWNER_LIMIT
+              value: {{ $personalProjectOwnerLimitValue | quote }}
+            {{- end }}
           {{ range $k, $v := .Values.env }}
             - name: {{ $k | quote }}
               value: {{ $v | quote }}
@@ -169,6 +174,11 @@ spec:
           {{- if .Values.oidc.admin.roles }}
             - name: OIDC_ADMIN_ROLES
               value: {{ join "," .Values.oidc.admin.roles | quote }}
+          {{- end }}
+          {{- $personalProjectOwnerRoles := .Values.oidc.personalProjectOwner.roles }}
+          {{- if $personalProjectOwnerRoles }}
+            - name: OIDC_PERSONNAL_PROJECT_OWNER_ROLES
+              value: {{ join "," $personalProjectOwnerRoles | quote }}
           {{- end }}
             - name: OIDC_ROLES_ATTRIBUTE
               value: {{ .Values.oidc.admin.rolesAttribute | default "groups" | quote }}

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -31,6 +31,10 @@ existingAdminCredsSecret: ""
 # Defaults to `http://localhost:3000` if ingress is disabled.
 baseUrl: ""
 
+## @param personalProjectOwnerLimit Maximum number of personal projects each personal project owner can create.
+## Leave empty to use the application default (currently 2).
+personalProjectOwnerLimit: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -200,6 +204,13 @@ oidc:
     ##
     roles: []
       # - planka-admin
+
+  personalProjectOwner:
+    ## @param oidc.personalProjectOwner.roles The groups that should receive the personal project owner role.
+    ## These map to the `OIDC_PERSONNAL_PROJECT_OWNER_ROLES` environment variable.
+    ##
+    roles: []
+      # - personnal_project_owner
 
 ## Extra environment variables for planka deployment
 ## Supports hard coded and getting values from a k8s secret


### PR DESCRIPTION
## Summary
- document the personal project owner role, default project cap, and related environment variables in the main README and Helm chart docs
- expose `PERSONNAL_PROJECT_OWNER_LIMIT` and `OIDC_PERSONNAL_PROJECT_OWNER_ROLES` through the Helm chart values and deployment template

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94d0d27408323ab5e38088a467280