### PR TITLE
Fix helper initialization to avoid referencing User before lift

### DIFF
--- a/server/api/helpers/users/is-admin-or-project-owner.js
+++ b/server/api/helpers/users/is-admin-or-project-owner.js
@@ -3,11 +3,7 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
-const PROJECT_CREATION_ROLES = new Set([
-  User.Roles.ADMIN,
-  User.Roles.PROJECT_OWNER,
-  User.Roles.PERSONAL_PROJECT_OWNER,
-]);
+let projectCreationRoles;
 
 module.exports = {
   sync: true,
@@ -20,6 +16,14 @@ module.exports = {
   },
 
   fn(inputs) {
-    return PROJECT_CREATION_ROLES.has(inputs.record.role);
+    if (!projectCreationRoles) {
+      projectCreationRoles = new Set([
+        User.Roles.ADMIN,
+        User.Roles.PROJECT_OWNER,
+        User.Roles.PERSONAL_PROJECT_OWNER,
+      ]);
+    }
+
+    return projectCreationRoles.has(inputs.record.role);
   },
 };


### PR DESCRIPTION
## Summary
- lazily initialize the set of project creation roles inside the helper
- avoid referencing the User global before Sails finishes lifting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95a3f5f1c832384318426241c85e5