### PR TITLE
Add planner import processing helper

### DIFF
--- a/server/api/helpers/boards/process-uploaded-planner-import-file.js
+++ b/server/api/helpers/boards/process-uploaded-planner-import-file.js
@@ -1,0 +1,478 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const XLSX = require('xlsx');
+const moment = require('moment');
+const { rimraf } = require('rimraf');
+
+const DATE_FORMATS = [
+  'YYYY-MM-DD',
+  'YYYY-MM-DD HH:mm',
+  'YYYY-MM-DD HH:mm:ss',
+  'YYYY-MM-DDTHH:mm',
+  'YYYY-MM-DDTHH:mm:ss',
+  'YYYY/MM/DD',
+  'YYYY/MM/DD HH:mm',
+  'YYYY/MM/DD HH:mm:ss',
+  'DD/MM/YYYY',
+  'DD/MM/YYYY HH:mm',
+  'DD/MM/YYYY HH:mm:ss',
+  'D/M/YYYY',
+  'D/M/YYYY HH:mm',
+  'D/M/YYYY HH:mm:ss',
+  'MM/DD/YYYY',
+  'MM/DD/YYYY HH:mm',
+  'MM/DD/YYYY HH:mm:ss',
+  'M/D/YYYY',
+  'M/D/YYYY HH:mm',
+  'M/D/YYYY HH:mm:ss',
+  'DD.MM.YYYY',
+  'DD.MM.YYYY HH:mm',
+  'DD.MM.YYYY HH:mm:ss',
+  'D.M.YYYY',
+  'D.M.YYYY HH:mm',
+  'D.M.YYYY HH:mm:ss',
+  'DD-MM-YYYY',
+  'DD-MM-YYYY HH:mm',
+  'DD-MM-YYYY HH:mm:ss',
+  'D-M-YYYY',
+  'D-M-YYYY HH:mm',
+  'D-M-YYYY HH:mm:ss',
+];
+
+const DATE_FIELDS = new Set([
+  'startDate',
+  'dueDate',
+  'completedDate',
+  'completedAt',
+  'createdDate',
+  'createdAt',
+  'updatedDate',
+  'updatedAt',
+  'actualStartDate',
+  'actualEndDate',
+  'checklistCompletedAt',
+]);
+
+const BOOLEAN_FIELDS = new Set([
+  'isCompleted',
+  'hasChecklist',
+  'isArchived',
+  'checklistIsCompleted',
+]);
+
+const MULTI_VALUE_FIELDS = new Set(['labels', 'checklistItems', 'assignments', 'categories']);
+
+const BOOLEAN_TRUE_VALUES = new Set([
+  'true',
+  '1',
+  'yes',
+  'y',
+  'oui',
+  'vrai',
+  'done',
+  'complete',
+  'completed',
+  'termine',
+  'terminee',
+  'acheve',
+  'achevee',
+]);
+
+const BOOLEAN_FALSE_VALUES = new Set([
+  'false',
+  '0',
+  'no',
+  'n',
+  'non',
+  'faux',
+  'not done',
+  'not completed',
+  'incomplete',
+  'incomplet',
+  'non termine',
+  'non terminee',
+]);
+
+const HEADER_ALIASES = {
+  'id de tache': 'taskId',
+  'task id': 'taskId',
+  id: 'taskId',
+  'plan id': 'planId',
+  'nom du plan': 'planName',
+  'plan name': 'planName',
+  'nom du compartiment': 'bucketName',
+  'bucket name': 'bucketName',
+  titre: 'title',
+  title: 'title',
+  description: 'description',
+  notes: 'notes',
+  priorite: 'priority',
+  priority: 'priority',
+  importance: 'priority',
+  avancement: 'progress',
+  progression: 'progress',
+  progress: 'progress',
+  'date de debut': 'startDate',
+  'start date': 'startDate',
+  'date decheance': 'dueDate',
+  'date d echeance': 'dueDate',
+  'due date': 'dueDate',
+  'date de fin': 'completedDate',
+  'date de fin reelle': 'completedDate',
+  'completion date': 'completedDate',
+  'date de creation': 'createdDate',
+  'created date': 'createdDate',
+  'creation date': 'createdDate',
+  'date de mise a jour': 'updatedDate',
+  'last modified date': 'updatedDate',
+  'updated date': 'updatedDate',
+  termine: 'isCompleted',
+  terminee: 'isCompleted',
+  acheve: 'isCompleted',
+  achevee: 'isCompleted',
+  completed: 'isCompleted',
+  'is completed': 'isCompleted',
+  etiquettes: 'labels',
+  labels: 'labels',
+  categorie: 'categories',
+  categories: 'categories',
+  'elements de la liste de controle': 'checklistItems',
+  'element de la liste de controle': 'checklistItems',
+  'elements de liste de controle': 'checklistItems',
+  'checklist items': 'checklistItems',
+  'etat des elements de la liste de controle': 'checklistState',
+  'statut des elements de la liste de controle': 'checklistState',
+  'checklist items state': 'checklistState',
+  'achevement de la liste de controle': 'checklistProgress',
+  'progression de la liste de controle': 'checklistProgress',
+  'checklist items progress': 'checklistProgress',
+  attributions: 'assignments',
+  assignations: 'assignments',
+  assignes: 'assignments',
+  assignees: 'assignments',
+  affectations: 'assignments',
+  responsables: 'assignments',
+};
+
+const sanitizeString = (value) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+const toCamelCase = (value) => {
+  const cleaned = sanitizeString(value)
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+  if (!cleaned) {
+    return '';
+  }
+
+  return cleaned
+    .split(' ')
+    .filter(Boolean)
+    .map((part, index) => {
+      if (index === 0) {
+        return part;
+      }
+
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join('');
+};
+
+const createHeaderNormalizer = () => {
+  const occurrences = {};
+
+  return (header) => {
+    if (header === null || header === undefined) {
+      return null;
+    }
+
+    const trimmed = String(header).trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const normalized = sanitizeString(trimmed)
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+
+    let key = HEADER_ALIASES[normalized];
+
+    if (!key) {
+      key = toCamelCase(trimmed);
+    }
+
+    if (!key) {
+      return null;
+    }
+
+    const count = occurrences[key] || 0;
+    occurrences[key] = count + 1;
+
+    if (count > 0) {
+      return `${key}${count + 1}`;
+    }
+
+    return key;
+  };
+};
+
+const isCellEmpty = (value) => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() === '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  return false;
+};
+
+const parseBoolean = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = sanitizeString(value).trim();
+    if (!normalized) {
+      return null;
+    }
+
+    if (BOOLEAN_TRUE_VALUES.has(normalized)) {
+      return true;
+    }
+
+    if (BOOLEAN_FALSE_VALUES.has(normalized)) {
+      return false;
+    }
+  }
+
+  return null;
+};
+
+const parseDateValue = (value, { date1904 }) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'number') {
+    const parsed = XLSX.SSF.parse_date_code(value, { date1904 });
+    if (!parsed) {
+      return null;
+    }
+
+    const { y, m, d, H, M, S } = parsed;
+    const milliseconds = Math.round((S - Math.floor(S)) * 1000);
+
+    return new Date(Date.UTC(y, m - 1, d, H, M, Math.floor(S), milliseconds)).toISOString();
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    let parsedMoment = moment(trimmed, moment.ISO_8601, true);
+
+    if (!parsedMoment.isValid()) {
+      parsedMoment = moment(trimmed, DATE_FORMATS, true);
+    }
+
+    if (parsedMoment.isValid()) {
+      return parsedMoment.toDate().toISOString();
+    }
+
+    return trimmed;
+  }
+
+  return null;
+};
+
+const parseMultiValue = (value) => {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((item) => parseMultiValue(item))
+      .filter((item, index, array) => array.indexOf(item) === index);
+  }
+
+  const text = String(value).trim();
+  if (!text) {
+    return [];
+  }
+
+  return text
+    .split(/[\n;,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const transformValue = (key, value, workbookOptions) => {
+  if (MULTI_VALUE_FIELDS.has(key)) {
+    return parseMultiValue(value);
+  }
+
+  if (DATE_FIELDS.has(key)) {
+    return parseDateValue(value, workbookOptions);
+  }
+
+  if (BOOLEAN_FIELDS.has(key)) {
+    return parseBoolean(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed === '' ? null : trimmed;
+  }
+
+  if (value === undefined) {
+    return null;
+  }
+
+  return value;
+};
+
+module.exports = {
+  inputs: {
+    file: {
+      type: 'json',
+      required: true,
+    },
+  },
+
+  exits: {
+    invalidFile: {},
+  },
+
+  async fn(inputs) {
+    let workbook;
+
+    try {
+      workbook = XLSX.readFile(inputs.file.fd, {
+        cellDates: true,
+      });
+    } catch (error) {
+      await rimraf(inputs.file.fd);
+      throw 'invalidFile';
+    }
+
+    let result;
+    try {
+      const sheetName = workbook.SheetNames[0];
+      if (!sheetName) {
+        throw 'invalidFile';
+      }
+
+      const sheet = workbook.Sheets[sheetName];
+      if (!sheet) {
+        throw 'invalidFile';
+      }
+
+      const rows = XLSX.utils.sheet_to_json(sheet, {
+        header: 1,
+        raw: true,
+        defval: null,
+        blankrows: false,
+      });
+
+      if (rows.length === 0) {
+        result = {
+          fileName: inputs.file.filename || null,
+          sheetName,
+          columns: [],
+          rows: [],
+        };
+
+        return result;
+      }
+
+      const [headerRow, ...dataRows] = rows;
+      const normalizeHeader = createHeaderNormalizer();
+      const normalizedHeaders = headerRow.map((header) => normalizeHeader(header));
+
+      const workbookOptions = {
+        date1904: Boolean(
+          workbook &&
+            workbook.Workbook &&
+            workbook.Workbook.WBProps &&
+            workbook.Workbook.WBProps.date1904,
+        ),
+      };
+
+      const normalizedRows = dataRows
+        .filter((row) => row.some((cell) => !isCellEmpty(cell)))
+        .map((row) => {
+          const entry = {};
+
+          normalizedHeaders.forEach((key, index) => {
+            if (!key) {
+              return;
+            }
+
+            const transformed = transformValue(key, row[index], workbookOptions);
+            entry[key] = transformed;
+          });
+
+          return entry;
+        });
+
+      const columns = headerRow
+        .map((original, index) => {
+          const key = normalizedHeaders[index];
+          if (!key) {
+            return null;
+          }
+
+          return {
+            key,
+            original,
+          };
+        })
+        .filter(Boolean);
+
+      result = {
+        fileName: inputs.file.filename || null,
+        sheetName,
+        columns,
+        rows: normalizedRows,
+      };
+
+      return result;
+    } catch (error) {
+      if (error === 'invalidFile') {
+        throw error;
+      }
+
+      throw 'invalidFile';
+    } finally {
+      await rimraf(inputs.file.fd);
+    }
+  },
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -36,6 +36,7 @@
         "uuid": "^9.0.1",
         "validator": "^13.15.15",
         "winston": "^3.17.0",
+        "xlsx": "^0.18.5",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -4191,6 +4192,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -5049,6 +5059,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5168,6 +5191,15 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -5498,6 +5530,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-env": {
@@ -7240,6 +7284,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -13054,6 +13107,18 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -14490,6 +14555,24 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -14597,6 +14680,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xtend": {

--- a/server/package.json
+++ b/server/package.json
@@ -72,6 +72,7 @@
     "uuid": "^9.0.1",
     "validator": "^13.15.15",
     "winston": "^3.17.0",
+    "xlsx": "^0.18.5",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/server/tests/boards.process-uploaded-planner-import-file.test.js
+++ b/server/tests/boards.process-uploaded-planner-import-file.test.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const XLSX = require('xlsx');
+
+const helper = require('../api/helpers/boards/process-uploaded-planner-import-file');
+
+const excelSerialFromIso = (iso) => {
+  const date = new Date(iso);
+  const excelEpoch = Date.UTC(1899, 11, 30);
+
+  return (date.getTime() - excelEpoch) / 86400000;
+};
+
+describe('boards/process-uploaded-planner-import-file helper', () => {
+  let tmpDir;
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.promises.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  test('parses rows and normalizes values from an Excel workbook', async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'planner-import-'));
+    const filePath = path.join(tmpDir, 'planner.xlsx');
+
+    const sheetData = [
+      [
+        'ID de tâche',
+        'Nom du compartiment',
+        'Date de début',
+        "Date d'échéance",
+        'Terminé',
+        'Étiquettes',
+        'Éléments de la liste de contrôle',
+      ],
+      [
+        'task-1',
+        'Backlog',
+        excelSerialFromIso('2024-01-05T00:00:00.000Z'),
+        '01/02/2024 15:30',
+        'Oui',
+        'Rouge, Vert',
+        'Item A\nItem B',
+      ],
+    ];
+
+    const workbook = XLSX.utils.book_new();
+    const worksheet = XLSX.utils.aoa_to_sheet(sheetData);
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Plan');
+    XLSX.writeFile(workbook, filePath);
+
+    const result = await helper.fn({
+      file: {
+        fd: filePath,
+        filename: 'planner.xlsx',
+      },
+    });
+
+    expect(result.fileName).toBe('planner.xlsx');
+    expect(result.sheetName).toBe('Plan');
+    expect(result.columns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'taskId', original: 'ID de tâche' }),
+        expect.objectContaining({ key: 'bucketName', original: 'Nom du compartiment' }),
+      ]),
+    );
+
+    expect(result.rows).toHaveLength(1);
+    const [row] = result.rows;
+
+    expect(row).toMatchObject({
+      taskId: 'task-1',
+      bucketName: 'Backlog',
+      startDate: '2024-01-05T00:00:00.000Z',
+      dueDate: '2024-02-01T15:30:00.000Z',
+      isCompleted: true,
+      labels: ['Rouge', 'Vert'],
+      checklistItems: ['Item A', 'Item B'],
+    });
+
+    await expect(fs.promises.access(filePath)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add the `xlsx` dependency to the server package to support Excel-based imports
- implement a Planner import helper that normalizes headers, converts values, and cleans up temporary files
- add Jest coverage to verify parsing of dates, booleans, labels, and checklist data

## Testing
- npm run lint --prefix server
- npm test --prefix server
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca56bd4274832381040cd385c58679