### PR TITLE
Add Microsoft Planner import helper

### DIFF
--- a/server/api/controllers/boards/create.js
+++ b/server/api/controllers/boards/create.js
@@ -104,6 +104,15 @@ module.exports = {
           type: inputs.importType,
           board: trelloBoard,
         };
+      } else if (inputs.importType === Board.ImportTypes.PLANNER) {
+        const planner = await sails.helpers.boards
+          .processUploadedPlannerImportFile(file)
+          .intercept('invalidFile', () => Errors.INVALID_IMPORT_FILE);
+
+        boardImport = {
+          type: inputs.importType,
+          planner,
+        };
       }
     }
 

--- a/server/api/helpers/boards/create-one.js
+++ b/server/api/helpers/boards/create-one.js
@@ -101,8 +101,19 @@ module.exports = {
       },
     );
 
-    if (inputs.import && inputs.import.type === Board.ImportTypes.TRELLO) {
-      await sails.helpers.boards.importFromTrello(board, lists, inputs.import.board);
+    if (inputs.import) {
+      if (inputs.import.type === Board.ImportTypes.TRELLO) {
+        await sails.helpers.boards.importFromTrello(board, lists, inputs.import.board);
+      } else if (inputs.import.type === Board.ImportTypes.PLANNER) {
+        await sails.helpers.boards.importFromPlanner.with({
+          board,
+          lists,
+          planner: inputs.import.planner,
+          project: values.project,
+          actorUser: inputs.actorUser,
+          request: inputs.request,
+        });
+      }
     }
 
     scoper.board = board;

--- a/server/api/helpers/boards/import-from-planner.js
+++ b/server/api/helpers/boards/import-from-planner.js
@@ -1,0 +1,666 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const { POSITION_GAP } = require('../../../constants');
+
+const BOOLEAN_TRUE_VALUES = new Set([
+  'true',
+  '1',
+  'yes',
+  'y',
+  'oui',
+  'vrai',
+  'done',
+  'complete',
+  'completed',
+  'termine',
+  'terminee',
+  'acheve',
+  'achevee',
+]);
+
+const BOOLEAN_FALSE_VALUES = new Set([
+  'false',
+  '0',
+  'no',
+  'n',
+  'non',
+  'faux',
+  'not done',
+  'not completed',
+  'incomplete',
+  'incomplet',
+  'non termine',
+  'non terminee',
+]);
+
+const stripDiacritics = (value) => value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+const normalizeText = (value) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const text = stripDiacritics(String(value))
+    .replace(/\(.*?\)/g, ' ')
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .toLowerCase()
+    .trim();
+
+  return text.replace(/\s+/g, ' ');
+};
+
+const slugify = (value) => {
+  const base = stripDiacritics(String(value || ''))
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+  return base || 'list';
+};
+
+const getUniqueSlug = (name, usedSlugs) => {
+  const baseSlug = slugify(name);
+  let slug = baseSlug;
+  let counter = 2;
+
+  while (usedSlugs.has(slug)) {
+    slug = `${baseSlug}-${counter}`;
+    counter += 1;
+  }
+
+  usedSlugs.add(slug);
+  return slug;
+};
+
+const isEmptyValue = (value) => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() === '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  return false;
+};
+
+const getFirstNonEmpty = (object, keys) => {
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = keys[index];
+    if (key && Object.prototype.hasOwnProperty.call(object, key)) {
+      const value = object[key];
+      if (!isEmptyValue(value)) {
+        return value;
+      }
+    }
+  }
+
+  return null;
+};
+
+const parseBooleanish = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return null;
+  }
+
+  if (BOOLEAN_TRUE_VALUES.has(normalized)) {
+    return true;
+  }
+
+  if (BOOLEAN_FALSE_VALUES.has(normalized)) {
+    return false;
+  }
+
+  return null;
+};
+
+const toArray = (value) => {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((item) => toArray(item))
+      .map((item) => (item === null || item === undefined ? '' : String(item).trim()))
+      .filter(Boolean);
+  }
+
+  return String(value)
+    .split(/[;,\n]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+const collectNameEntries = (...values) => {
+  const entries = [];
+  const seen = new Set();
+
+  values.forEach((value) => {
+    toArray(value).forEach((item) => {
+      const trimmed = item.trim();
+      const normalized = normalizeText(trimmed);
+      if (!normalized || seen.has(normalized)) {
+        return;
+      }
+
+      seen.add(normalized);
+      entries.push({ original: trimmed, normalized });
+    });
+  });
+
+  return entries;
+};
+
+const parseChecklistCompletedCount = (value) => {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const match = String(value).match(/\d+/);
+  if (!match) {
+    return 0;
+  }
+
+  return Number.parseInt(match[0], 10);
+};
+
+const getCompletedDate = (row) =>
+  getFirstNonEmpty(row, ['completedDate', 'completedAt', 'actualEndDate']);
+
+const getStartDate = (row) => getFirstNonEmpty(row, ['startDate', 'actualStartDate']);
+
+const getDueDate = (row) => getFirstNonEmpty(row, ['dueDate', 'due']);
+
+const getBucketName = (row, t) => {
+  const bucket = getFirstNonEmpty(row, ['bucketName', 'bucket']);
+  const text = bucket === null || bucket === undefined ? '' : String(bucket).trim();
+
+  return text || t('No bucket');
+};
+
+const getCardName = (row, t) => {
+  const name = getFirstNonEmpty(row, ['title', 'name', 'taskName']);
+
+  if (!isEmptyValue(name)) {
+    return String(name).trim();
+  }
+
+  const fallback = getFirstNonEmpty(row, ['taskId', 'id']);
+  if (!isEmptyValue(fallback)) {
+    return String(fallback).trim();
+  }
+
+  return t('Imported task');
+};
+
+const getPlannerDescription = (row) => {
+  const description = getFirstNonEmpty(row, ['description', 'notes']);
+
+  if (isEmptyValue(description)) {
+    return null;
+  }
+
+  return String(description).trim();
+};
+
+module.exports = {
+  inputs: {
+    board: {
+      type: 'ref',
+      required: true,
+    },
+    lists: {
+      type: 'ref',
+      required: true,
+    },
+    planner: {
+      type: 'json',
+      required: true,
+    },
+    project: {
+      type: 'ref',
+      required: true,
+    },
+    actorUser: {
+      type: 'ref',
+      required: true,
+    },
+    request: {
+      type: 'ref',
+    },
+  },
+
+  async fn({ board, lists, planner, project, actorUser, request }) {
+    const locale = actorUser.language || (request && request.getLocale && request.getLocale());
+    const t = sails.helpers.utils.makeTranslator(locale);
+
+    const plannerRows = Array.isArray(planner.rows) ? planner.rows : [];
+    if (plannerRows.length === 0) {
+      return;
+    }
+
+    const archiveList = lists.find((list) => list.type === List.Types.ARCHIVE) || null;
+
+    const usedListSlugs = new Set(
+      lists
+        .map((list) => list.slug)
+        .filter(Boolean)
+        .map((slug) => slug.toLowerCase()),
+    );
+
+    const bucketEntries = [];
+    const bucketByKey = new Map();
+
+    plannerRows.forEach((row) => {
+      const bucketName = getBucketName(row, t);
+      const bucketKey = normalizeText(bucketName) || '__bucket__';
+      let entry = bucketByKey.get(bucketKey);
+      if (!entry) {
+        entry = { key: bucketKey, name: bucketName, rows: [] };
+        bucketByKey.set(bucketKey, entry);
+        bucketEntries.push(entry);
+      }
+
+      entry.rows.push(row);
+    });
+
+    const listByBucketKey = new Map();
+    let listIndex = 0;
+
+    for (let entryIndex = 0; entryIndex < bucketEntries.length; entryIndex += 1) {
+      const entry = bucketEntries[entryIndex];
+      if (entry.rows.length > 0) {
+        const allCompleted = entry.rows.every((row) => Boolean(getCompletedDate(row)));
+        const type = allCompleted ? List.Types.CLOSED : List.Types.ACTIVE;
+        const slug = getUniqueSlug(entry.name, usedListSlugs);
+
+        // eslint-disable-next-line no-await-in-loop
+        const list = await List.qm.createOne({
+          boardId: board.id,
+          type,
+          position: POSITION_GAP * (listIndex + 1),
+          name: entry.name,
+          slug,
+        });
+
+        listIndex += 1;
+        listByBucketKey.set(entry.key, list);
+      }
+    }
+
+    const importantColor = Label.COLORS.find((color) => color.includes('red')) || Label.COLORS[0];
+    const availableLabelColors = Label.COLORS.filter((color) => color !== importantColor);
+    let labelColorIndex = 0;
+    const labelByNormalizedName = new Map();
+    let labelPositionIndex = 0;
+
+    const getNextLabelPosition = () => {
+      labelPositionIndex += 1;
+      return POSITION_GAP * labelPositionIndex;
+    };
+
+    const getNextLabelColor = () => {
+      if (availableLabelColors.length === 0) {
+        return importantColor;
+      }
+
+      const color = availableLabelColors[labelColorIndex % availableLabelColors.length];
+      labelColorIndex += 1;
+      return color;
+    };
+
+    const ensureLabel = async (name, { color } = {}) => {
+      if (!name) {
+        return null;
+      }
+
+      const normalized = normalizeText(name);
+      if (!normalized) {
+        return null;
+      }
+
+      if (labelByNormalizedName.has(normalized)) {
+        return labelByNormalizedName.get(normalized);
+      }
+
+      const resolvedColor = color || getNextLabelColor();
+      const position = getNextLabelPosition();
+
+      const label = await Label.qm.createOne({
+        boardId: board.id,
+        position,
+        name,
+        color: resolvedColor,
+      });
+
+      labelByNormalizedName.set(normalized, label);
+      return label;
+    };
+
+    const importantLabel = await ensureLabel(t('Important'), { color: importantColor });
+
+    const labelsToCreate = [];
+    plannerRows.forEach((row) => {
+      toArray(row.labels).forEach((labelName) => {
+        const normalized = normalizeText(labelName);
+        if (!normalized) {
+          return;
+        }
+
+        if (labelByNormalizedName.has(normalized)) {
+          return;
+        }
+
+        if (labelsToCreate.some((item) => item.normalized === normalized)) {
+          return;
+        }
+
+        labelsToCreate.push({ normalized, name: labelName });
+      });
+    });
+
+    for (let labelIndex = 0; labelIndex < labelsToCreate.length; labelIndex += 1) {
+      const labelEntry = labelsToCreate[labelIndex];
+      // eslint-disable-next-line no-await-in-loop
+      await ensureLabel(labelEntry.name);
+    }
+
+    const users = await User.qm.getAll();
+    const userByNormalizedName = new Map();
+    users.forEach((user) => {
+      const normalized = normalizeText(user.name);
+      if (!normalized || userByNormalizedName.has(normalized)) {
+        return;
+      }
+
+      userByNormalizedName.set(normalized, user);
+    });
+
+    const findUserByNormalized = (normalized) => userByNormalizedName.get(normalized) || null;
+
+    const existingBoardMemberships = (await BoardMembership.qm.getByBoardId(board.id)) || [];
+    const boardMemberUserIds = new Set(
+      existingBoardMemberships.map((membership) => membership.userId),
+    );
+
+    const ensureBoardMembership = async (user) => {
+      if (!user || boardMemberUserIds.has(user.id)) {
+        return;
+      }
+
+      await BoardMembership.qm.createOne({
+        projectId: project.id,
+        boardId: board.id,
+        userId: user.id,
+        role: BoardMembership.Roles.EDITOR,
+      });
+
+      boardMemberUserIds.add(user.id);
+    };
+
+    const importDate = new Date().toISOString();
+    const cardPositionByListId = new Map();
+
+    const getNextCardPosition = (listId) => {
+      const current = cardPositionByListId.get(listId) || 0;
+      const next = current + 1;
+      cardPositionByListId.set(listId, next);
+      return POSITION_GAP * next;
+    };
+
+    const recurringLabelName = t('Recurring');
+    const lateLabelName = t('Late');
+
+    for (let entryIndex = 0; entryIndex < bucketEntries.length; entryIndex += 1) {
+      const entry = bucketEntries[entryIndex];
+      const bucketList = listByBucketKey.get(entry.key);
+
+      for (let rowIndex = 0; rowIndex < entry.rows.length; rowIndex += 1) {
+        const row = entry.rows[rowIndex];
+        const creatorEntries = collectNameEntries(row.createdBy, row.creePar);
+        const creatorUser = creatorEntries
+          .map((entryItem) => findUserByNormalized(entryItem.normalized))
+          .find(Boolean);
+
+        const cardName = getCardName(row, t);
+        const plannerDescription = getPlannerDescription(row);
+        const metaLines = [];
+
+        const plannerTaskId = getFirstNonEmpty(row, ['taskId', 'id']);
+        if (!isEmptyValue(plannerTaskId)) {
+          metaLines.push(`- ${t('Task ID')}: ${String(plannerTaskId).trim()}`);
+        }
+
+        const progressValue = getFirstNonEmpty(row, ['progress']);
+        if (!isEmptyValue(progressValue)) {
+          metaLines.push(`- ${t('Progress')}: ${String(progressValue).trim()}`);
+        }
+
+        const planName = getFirstNonEmpty(row, ['planName']);
+        if (!isEmptyValue(planName)) {
+          metaLines.push(`- ${t('Plan')}: ${String(planName).trim()}`);
+        }
+
+        const executedEntries = collectNameEntries(row.executePar, row.executedBy, row.completedBy);
+        if (executedEntries.length > 0) {
+          metaLines.push(
+            `- ${t('Completed by')}: ${executedEntries.map((entryItem) => entryItem.original).join(', ')}`,
+          );
+        }
+
+        const completedDate = getCompletedDate(row);
+        const startDate = getStartDate(row);
+        const dueDate = getDueDate(row);
+
+        const isArchived = parseBooleanish(row.isArchived);
+        const isRecurring = parseBooleanish(
+          getFirstNonEmpty(row, ['estPeriodique', 'isRecurring']),
+        );
+        const isLate = parseBooleanish(getFirstNonEmpty(row, ['enRetard', 'isLate']));
+
+        const targetList = bucketList || archiveList || null;
+        const finalList = isArchived && archiveList ? archiveList : targetList;
+
+        if (finalList) {
+          if (creatorUser) {
+            // eslint-disable-next-line no-await-in-loop
+            await ensureBoardMembership(creatorUser);
+          }
+
+          const prevListId = isArchived && archiveList && bucketList ? bucketList.id : null;
+          const position = getNextCardPosition(finalList.id);
+
+          const descriptionParts = [];
+          if (plannerDescription) {
+            descriptionParts.push(plannerDescription);
+          }
+
+          if (metaLines.length > 0) {
+            descriptionParts.push(`**${t('Planner Metadata')}**\n${metaLines.join('\n')}`);
+          }
+
+          const description = descriptionParts.length > 0 ? descriptionParts.join('\n\n') : null;
+
+          const cardValues = {
+            boardId: board.id,
+            listId: finalList.id,
+            type: board.defaultCardType || Card.Types.PROJECT,
+            position,
+            name: cardName,
+            description,
+            creatorUserId: creatorUser ? creatorUser.id : actorUser.id,
+            dueDate: dueDate || null,
+            ganttStartDate: startDate || null,
+            ganttEndDate: completedDate || null,
+            closedAt:
+              completedDate ||
+              (finalList.type === List.Types.CLOSED || finalList.type === List.Types.ARCHIVE
+                ? importDate
+                : null),
+            listChangedAt: importDate,
+          };
+
+          if (board.defaultCardTypeId) {
+            cardValues.cardTypeId = board.defaultCardTypeId;
+          }
+
+          if (prevListId) {
+            cardValues.prevListId = prevListId;
+          }
+
+          // eslint-disable-next-line no-await-in-loop
+          const card = await Card.qm.createOne(cardValues);
+
+          const cardMemberUserIds = new Set();
+          const ensureCardMembership = async (user) => {
+            if (!user || cardMemberUserIds.has(user.id)) {
+              return;
+            }
+
+            await CardMembership.qm.createOne({
+              cardId: card.id,
+              userId: user.id,
+            });
+
+            cardMemberUserIds.add(user.id);
+          };
+
+          const assignmentEntries = collectNameEntries(
+            row.assignments,
+            row.attribueA,
+            row.assignees,
+            row.assignedTo,
+            row.responsables,
+          );
+
+          for (
+            let assignmentIndex = 0;
+            assignmentIndex < assignmentEntries.length;
+            assignmentIndex += 1
+          ) {
+            const assignmentEntry = assignmentEntries[assignmentIndex];
+            const assignmentUser = findUserByNormalized(assignmentEntry.normalized);
+            if (assignmentUser) {
+              // eslint-disable-next-line no-await-in-loop
+              await ensureBoardMembership(assignmentUser);
+              // eslint-disable-next-line no-await-in-loop
+              await ensureCardMembership(assignmentUser);
+            }
+          }
+
+          for (let executedIndex = 0; executedIndex < executedEntries.length; executedIndex += 1) {
+            const executedEntry = executedEntries[executedIndex];
+            const executedUser = findUserByNormalized(executedEntry.normalized);
+            if (executedUser) {
+              // eslint-disable-next-line no-await-in-loop
+              await ensureBoardMembership(executedUser);
+              // eslint-disable-next-line no-await-in-loop
+              await ensureCardMembership(executedUser);
+            }
+          }
+
+          const labelIds = new Set();
+          const addUniqueLabel = async (label) => {
+            if (!label || labelIds.has(label.id)) {
+              return;
+            }
+
+            await CardLabel.qm.createOne({
+              cardId: card.id,
+              labelId: label.id,
+            });
+
+            labelIds.add(label.id);
+          };
+
+          const priority = getFirstNonEmpty(row, ['priority', 'importance']);
+          if (!isEmptyValue(priority)) {
+            const normalizedPriority = normalizeText(priority);
+            if (normalizedPriority.includes('important')) {
+              // eslint-disable-next-line no-await-in-loop
+              await addUniqueLabel(importantLabel);
+            }
+          }
+
+          const rowLabelNames = toArray(row.labels);
+          for (let labelIndex = 0; labelIndex < rowLabelNames.length; labelIndex += 1) {
+            const labelName = rowLabelNames[labelIndex];
+            // eslint-disable-next-line no-await-in-loop
+            await addUniqueLabel(await ensureLabel(labelName));
+          }
+
+          if (isRecurring === true) {
+            // eslint-disable-next-line no-await-in-loop
+            await addUniqueLabel(await ensureLabel(recurringLabelName));
+          }
+
+          if (isLate === true) {
+            // eslint-disable-next-line no-await-in-loop
+            await addUniqueLabel(await ensureLabel(lateLabelName));
+          }
+
+          const checklistItems = toArray(
+            getFirstNonEmpty(row, ['checklistItems', 'elementsDeLaListeDeControle']),
+          );
+          if (checklistItems.length > 0) {
+            const completedCount = parseChecklistCompletedCount(
+              getFirstNonEmpty(row, [
+                'elementsDeLaListeDeControleEffectues',
+                'checklistItemsChecked',
+                'checklistItemsCompleted',
+                'checklistCompletedItems',
+              ]),
+            );
+
+            // eslint-disable-next-line no-await-in-loop
+            const taskList = await TaskList.qm.createOne({
+              cardId: card.id,
+              position: POSITION_GAP,
+              name: t('Actions'),
+            });
+
+            for (
+              let checklistIndex = 0;
+              checklistIndex < checklistItems.length;
+              checklistIndex += 1
+            ) {
+              const checklistItem = checklistItems[checklistIndex];
+              // eslint-disable-next-line no-await-in-loop
+              await Task.qm.createOne({
+                taskListId: taskList.id,
+                position: POSITION_GAP * (checklistIndex + 1),
+                name: checklistItem,
+                isCompleted: checklistIndex < completedCount,
+              });
+            }
+          }
+        }
+      }
+    }
+  },
+};

--- a/server/api/models/Board.js
+++ b/server/api/models/Board.js
@@ -20,6 +20,7 @@ const Views = {
 
 const ImportTypes = {
   TRELLO: 'trello',
+  PLANNER: 'planner',
 };
 
 module.exports = {

--- a/server/tests/boards.import-from-planner.test.js
+++ b/server/tests/boards.import-from-planner.test.js
@@ -1,0 +1,359 @@
+const { POSITION_GAP } = require('../constants');
+
+const helper = require('../api/helpers/boards/import-from-planner');
+
+const originalGlobals = {
+  List: global.List,
+  Label: global.Label,
+  Card: global.Card,
+  BoardMembership: global.BoardMembership,
+  CardMembership: global.CardMembership,
+  CardLabel: global.CardLabel,
+  TaskList: global.TaskList,
+  Task: global.Task,
+  User: global.User,
+  sails: global.sails,
+};
+
+describe('boards/import-from-planner helper', () => {
+  beforeEach(() => {
+    global.List = {
+      Types: {
+        ACTIVE: 'active',
+        CLOSED: 'closed',
+        ARCHIVE: 'archive',
+        TRASH: 'trash',
+      },
+      qm: {
+        createOne: jest.fn(),
+      },
+    };
+
+    global.Label = {
+      COLORS: ['berry-red', 'pumpkin-orange', 'lagoon-blue', 'pink-tulip'],
+      qm: {
+        createOne: jest.fn(),
+      },
+    };
+
+    global.Card = {
+      Types: {
+        PROJECT: 'project',
+        STORY: 'story',
+      },
+      qm: {
+        createOne: jest.fn(),
+      },
+    };
+
+    global.BoardMembership = {
+      Roles: {
+        EDITOR: 'editor',
+      },
+      qm: {
+        getByBoardId: jest.fn(),
+        createOne: jest.fn(),
+      },
+    };
+
+    global.CardMembership = {
+      qm: {
+        createOne: jest.fn(),
+      },
+    };
+
+    global.CardLabel = {
+      qm: {
+        createOne: jest.fn(),
+      },
+    };
+
+    global.TaskList = {
+      qm: {
+        createOne: jest.fn(),
+      },
+    };
+
+    global.Task = {
+      qm: {
+        createOne: jest.fn(),
+      },
+    };
+
+    global.User = {
+      qm: {
+        getAll: jest.fn(),
+      },
+    };
+
+    global.sails = {
+      helpers: {
+        utils: {
+          makeTranslator: jest.fn().mockImplementation(() => (key) => key),
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+
+    if (typeof originalGlobals.List === 'undefined') {
+      delete global.List;
+    } else {
+      global.List = originalGlobals.List;
+    }
+
+    if (typeof originalGlobals.Label === 'undefined') {
+      delete global.Label;
+    } else {
+      global.Label = originalGlobals.Label;
+    }
+
+    if (typeof originalGlobals.Card === 'undefined') {
+      delete global.Card;
+    } else {
+      global.Card = originalGlobals.Card;
+    }
+
+    if (typeof originalGlobals.BoardMembership === 'undefined') {
+      delete global.BoardMembership;
+    } else {
+      global.BoardMembership = originalGlobals.BoardMembership;
+    }
+
+    if (typeof originalGlobals.CardMembership === 'undefined') {
+      delete global.CardMembership;
+    } else {
+      global.CardMembership = originalGlobals.CardMembership;
+    }
+
+    if (typeof originalGlobals.CardLabel === 'undefined') {
+      delete global.CardLabel;
+    } else {
+      global.CardLabel = originalGlobals.CardLabel;
+    }
+
+    if (typeof originalGlobals.TaskList === 'undefined') {
+      delete global.TaskList;
+    } else {
+      global.TaskList = originalGlobals.TaskList;
+    }
+
+    if (typeof originalGlobals.Task === 'undefined') {
+      delete global.Task;
+    } else {
+      global.Task = originalGlobals.Task;
+    }
+
+    if (typeof originalGlobals.User === 'undefined') {
+      delete global.User;
+    } else {
+      global.User = originalGlobals.User;
+    }
+
+    if (typeof originalGlobals.sails === 'undefined') {
+      delete global.sails;
+    } else {
+      global.sails = originalGlobals.sails;
+    }
+  });
+
+  test('creates lists, labels, cards, memberships and tasks from planner rows', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-06-15T09:00:00.000Z'));
+
+    const createdLists = [];
+    global.List.qm.createOne.mockImplementation(async (values) => {
+      const record = { id: `list-${createdLists.length + 1}`, ...values };
+      createdLists.push(record);
+      return record;
+    });
+
+    const createdLabels = [];
+    global.Label.qm.createOne.mockImplementation(async (values) => {
+      const record = { id: `label-${createdLabels.length + 1}`, ...values };
+      createdLabels.push(record);
+      return record;
+    });
+
+    const createdCards = [];
+    global.Card.qm.createOne.mockImplementation(async (values) => {
+      const record = { id: `card-${createdCards.length + 1}`, ...values };
+      createdCards.push(record);
+      return record;
+    });
+
+    const createdBoardMemberships = [];
+    global.BoardMembership.qm.getByBoardId.mockResolvedValue([{ userId: 'user-actor' }]);
+    global.BoardMembership.qm.createOne.mockImplementation(async (values) => {
+      createdBoardMemberships.push(values);
+      return values;
+    });
+
+    const createdCardMemberships = [];
+    global.CardMembership.qm.createOne.mockImplementation(async (values) => {
+      createdCardMemberships.push(values);
+      return values;
+    });
+
+    const createdCardLabels = [];
+    global.CardLabel.qm.createOne.mockImplementation(async (values) => {
+      createdCardLabels.push(values);
+      return values;
+    });
+
+    const createdTaskLists = [];
+    global.TaskList.qm.createOne.mockImplementation(async (values) => {
+      const record = { id: `task-list-${createdTaskLists.length + 1}`, ...values };
+      createdTaskLists.push(record);
+      return record;
+    });
+
+    const createdTasks = [];
+    global.Task.qm.createOne.mockImplementation(async (values) => {
+      createdTasks.push(values);
+      return values;
+    });
+
+    global.User.qm.getAll.mockResolvedValue([
+      { id: 'user-alice', name: 'Alice Martin' },
+      { id: 'user-bob', name: 'Bob Durant' },
+      { id: 'user-charlie', name: 'Charlie Durand' },
+    ]);
+
+    const board = { id: 'board-1', defaultCardType: 'project' };
+    const project = { id: 'project-1' };
+    const actorUser = { id: 'user-actor', language: 'fr' };
+    const request = { getLocale: jest.fn().mockReturnValue('fr') };
+    const lists = [
+      { id: 'list-archive', type: List.Types.ARCHIVE, slug: null },
+      { id: 'list-trash', type: List.Types.TRASH, slug: null },
+    ];
+
+    const planner = {
+      fileName: 'planner.xlsx',
+      sheetName: 'Plan',
+      rows: [
+        {
+          taskId: 'task-1',
+          title: 'Préparer dossier',
+          bucketName: 'En cours',
+          createdBy: 'Alice Martin',
+          assignments: 'Bob Durant',
+          dueDate: '2024-06-20T00:00:00.000Z',
+          startDate: '2024-06-10T00:00:00.000Z',
+          labels: 'Rouge;Vert',
+          priority: 'Important',
+          notes: 'Description initiale',
+        },
+        {
+          taskId: 'task-2',
+          title: 'Clôturer projet',
+          bucketName: 'Terminé',
+          createdBy: 'Alice Martin',
+          assignments: 'Charlie Durand;Bob Durant',
+          executedBy: 'Charlie Durand',
+          dueDate: '2024-06-05T00:00:00.000Z',
+          startDate: '2024-05-25T00:00:00.000Z',
+          completedDate: '2024-06-03T00:00:00.000Z',
+          labels: 'Vert;Bleu',
+          progress: '100%',
+          planName: 'Plan A',
+          estPeriodique: 'Oui',
+          enRetard: 'Oui',
+          checklistItems: 'Étape A;Étape B;Étape C',
+          elementsDeLaListeDeControleEffectues: 2,
+        },
+      ],
+    };
+
+    await helper.fn({ board, lists, planner, project, actorUser, request });
+
+    expect(global.sails.helpers.utils.makeTranslator).toHaveBeenCalledWith('fr');
+
+    expect(createdLists).toHaveLength(2);
+    expect(createdLists[0]).toMatchObject({
+      name: 'En cours',
+      type: List.Types.ACTIVE,
+      position: POSITION_GAP,
+      slug: 'en-cours',
+    });
+    expect(createdLists[1]).toMatchObject({
+      name: 'Terminé',
+      type: List.Types.CLOSED,
+      position: POSITION_GAP * 2,
+      slug: 'termine',
+    });
+
+    expect(createdLabels).toHaveLength(6);
+    expect(createdLabels[0]).toMatchObject({ name: 'Important', color: 'berry-red' });
+    expect(createdLabels.map((label) => label.name)).toEqual(
+      expect.arrayContaining(['Recurring', 'Late']),
+    );
+
+    expect(createdCards).toHaveLength(2);
+    expect(createdCards[0]).toMatchObject({
+      name: 'Préparer dossier',
+      listId: createdLists[0].id,
+      creatorUserId: 'user-alice',
+      dueDate: '2024-06-20T00:00:00.000Z',
+      ganttStartDate: '2024-06-10T00:00:00.000Z',
+      closedAt: null,
+      listChangedAt: new Date('2024-06-15T09:00:00.000Z').toISOString(),
+    });
+    expect(createdCards[0].description).toContain('**Planner Metadata**');
+    expect(createdCards[0].description).toContain('Task ID');
+
+    expect(createdCards[1]).toMatchObject({
+      name: 'Clôturer projet',
+      listId: createdLists[1].id,
+      ganttEndDate: '2024-06-03T00:00:00.000Z',
+      closedAt: '2024-06-03T00:00:00.000Z',
+    });
+    expect(createdCards[1].description).toContain('- Progress: 100%');
+    expect(createdCards[1].description).toContain('- Plan: Plan A');
+    expect(createdCards[1].description).toContain('- Completed by: Charlie Durand');
+
+    expect(createdBoardMemberships).toHaveLength(3);
+    expect(createdBoardMemberships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ userId: 'user-alice', role: 'editor' }),
+        expect.objectContaining({ userId: 'user-bob', role: 'editor' }),
+        expect.objectContaining({ userId: 'user-charlie', role: 'editor' }),
+      ]),
+    );
+
+    expect(createdCardMemberships).toHaveLength(3);
+    expect(createdCardMemberships).toEqual(
+      expect.arrayContaining([
+        { cardId: 'card-1', userId: 'user-bob' },
+        { cardId: 'card-2', userId: 'user-bob' },
+        { cardId: 'card-2', userId: 'user-charlie' },
+      ]),
+    );
+
+    expect(createdCardLabels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ cardId: 'card-1', labelId: createdLabels[0].id }),
+        expect.objectContaining({ cardId: 'card-1', labelId: createdLabels[1].id }),
+        expect.objectContaining({ cardId: 'card-1', labelId: createdLabels[2].id }),
+        expect.objectContaining({ cardId: 'card-2', labelId: createdLabels[2].id }),
+        expect.objectContaining({ cardId: 'card-2', labelId: createdLabels[3].id }),
+        expect.objectContaining({ cardId: 'card-2', labelId: createdLabels[4].id }),
+        expect.objectContaining({ cardId: 'card-2', labelId: createdLabels[5].id }),
+      ]),
+    );
+
+    expect(createdTaskLists).toHaveLength(1);
+    expect(createdTaskLists[0]).toMatchObject({
+      cardId: 'card-2',
+      name: 'Actions',
+    });
+
+    expect(createdTasks).toHaveLength(3);
+    expect(createdTasks[0]).toMatchObject({ isCompleted: true });
+    expect(createdTasks[1]).toMatchObject({ isCompleted: true });
+    expect(createdTasks[2]).toMatchObject({ isCompleted: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add planner import type to board creation and wire up planner file parsing
- implement planner import helper to create lists, labels, cards, memberships, and checklists
- add tests covering the planner import helper flow

## Testing
- npm run lint --prefix server
- npm test --prefix server
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca5dfae264832386fbc7e1426cd937