### PR TITLE
Add board and list configuration columns

### DIFF
--- a/server/api/helpers/migrations/add-column-if-not-exists.js
+++ b/server/api/helpers/migrations/add-column-if-not-exists.js
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const initKnex = require('knex');
+
+const knexfile = require('../../../db/knexfile');
+
+module.exports = {
+  inputs: {
+    knex: {
+      type: 'ref',
+    },
+    tableName: {
+      type: 'string',
+      required: true,
+    },
+    columnName: {
+      type: 'string',
+      required: true,
+    },
+    columnDefinition: {
+      type: 'ref',
+      required: true,
+    },
+  },
+
+  async fn(inputs) {
+    const { knex: providedKnex, tableName, columnName, columnDefinition } = inputs;
+
+    const knex = providedKnex || initKnex(knexfile);
+
+    try {
+      const hasColumn = await knex.schema.hasColumn(tableName, columnName);
+
+      if (!hasColumn) {
+        await knex.schema.table(tableName, columnDefinition);
+      }
+    } finally {
+      if (!providedKnex) {
+        await knex.destroy();
+      }
+    }
+  },
+};

--- a/server/api/models/Board.js
+++ b/server/api/models/Board.js
@@ -69,6 +69,11 @@ module.exports = {
       defaultsTo: false,
       columnName: 'always_display_card_creator',
     },
+    showCardCount: {
+      type: 'boolean',
+      defaultsTo: false,
+      columnName: 'show_card_count',
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/server/api/models/List.js
+++ b/server/api/models/List.js
@@ -87,6 +87,11 @@ module.exports = {
       model: 'CardType',
       columnName: 'default_card_type_id',
     },
+    cardLimit: {
+      type: 'number',
+      defaultsTo: 0,
+      columnName: 'card_limit',
+    },
     color: {
       type: 'string',
       custom: (value) => HEX_COLOR_REGEX.test(value) || COLORS.includes(value),

--- a/server/db/migrations/20250918120000_add_show_card_count_to_board_and_card_limit_to_list.js
+++ b/server/db/migrations/20250918120000_add_show_card_count_to_board_and_card_limit_to_list.js
@@ -1,0 +1,19 @@
+exports.up = async (knex) => {
+  await knex.schema.table('board', (table) => {
+    table.boolean('show_card_count').notNullable().defaultTo(false);
+  });
+
+  await knex.schema.table('list', (table) => {
+    table.integer('card_limit').notNullable().defaultTo(0);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('list', (table) => {
+    table.dropColumn('card_limit');
+  });
+
+  await knex.schema.table('board', (table) => {
+    table.dropColumn('show_card_count');
+  });
+};


### PR DESCRIPTION
## Summary
- add a migration that introduces `show_card_count` on boards and `card_limit` on lists with defaults
- expose the new board and list properties in the Waterline models and database upgrade flow
- provide a reusable helper so upgrade scripts can add the new columns when missing

## Testing
- npm run lint
- npm run server:test -- --runTestsByPath server/tests/constants.test.js server/tests/validators.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d242ad64248323a98019205ee81b98