### PR TITLE
feat: add card limit selectors and model defaults

### DIFF
--- a/client/src/models/Board.js
+++ b/client/src/models/Board.js
@@ -33,6 +33,9 @@ export default class extends BaseModel {
     defaultCardTypeId: attr(),
     limitCardTypesToDefaultOne: attr(),
     alwaysDisplayCardCreator: attr(),
+    showCardCount: attr({
+      getDefault: () => false,
+    }),
     context: attr(),
     view: attr(),
     search: attr(),

--- a/client/src/models/List.js
+++ b/client/src/models/List.js
@@ -40,6 +40,9 @@ export default class extends BaseModel {
     color: attr(),
     defaultCardType: attr(),
     defaultCardTypeId: attr(),
+    cardLimit: attr({
+      getDefault: () => 0,
+    }),
     lastCard: attr({
       getDefault: () => null,
     }),

--- a/client/src/selectors/lists.js
+++ b/client/src/selectors/lists.js
@@ -47,6 +47,63 @@ export const makeSelectCardIdsByListId = () =>
 
 export const selectCardIdsByListId = makeSelectCardIdsByListId();
 
+export const makeSelectCardCountByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    ({ List }, id) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      return listModel.getCardsModelArray().length;
+    },
+  );
+
+export const selectCardCountByListId = makeSelectCardCountByListId();
+
+export const makeSelectIsCardLimitReachedByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    ({ List }, id) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      const count = listModel.getCardsModelArray().length;
+      const limit = listModel.cardLimit;
+
+      return limit > 0 && count >= limit;
+    },
+  );
+
+export const selectIsCardLimitReachedByListId = makeSelectIsCardLimitReachedByListId();
+
+export const makeSelectIsCardLimitBlockingByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    ({ List }, id) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      const count = listModel.getCardsModelArray().length;
+      const limit = listModel.cardLimit;
+
+      return limit > 0 && count >= limit * 2;
+    },
+  );
+
+export const selectIsCardLimitBlockingByListId = makeSelectIsCardLimitBlockingByListId();
+
 export const makeSelectFilteredCardIdsByListId = () =>
   createSelector(
     orm,
@@ -184,6 +241,12 @@ export default {
   selectListById,
   makeSelectCardIdsByListId,
   selectCardIdsByListId,
+  makeSelectCardCountByListId,
+  selectCardCountByListId,
+  makeSelectIsCardLimitReachedByListId,
+  selectIsCardLimitReachedByListId,
+  makeSelectIsCardLimitBlockingByListId,
+  selectIsCardLimitBlockingByListId,
   makeSelectFilteredCardIdsByListId,
   selectFilteredCardIdsByListId,
   makeSelectStoryPointsTotalByListId,


### PR DESCRIPTION
## Summary
- add a `showCardCount` default flag to boards and a `cardLimit` default to lists
- add selectors to expose card counts and limit status for lists and export them

## Testing
- npm run client:test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d24fdfa2bc8323add0df40a7ebb360