### PR TITLE
feat: add card limit editing step

### DIFF
--- a/client/src/components/lists/List/ActionsStep.jsx
+++ b/client/src/components/lists/List/ActionsStep.jsx
@@ -18,6 +18,7 @@ import EditColorStep from './EditColorStep';
 import SortStep from './SortStep';
 import SelectListTypeStep from '../SelectListTypeStep';
 import EditDefaultCardTypeStep from './EditDefaultCardTypeStep';
+import EditCardLimitStep from './EditCardLimitStep';
 import ConfirmationStep from '../../common/ConfirmationStep';
 import ArchiveCardsStep from '../../cards/ArchiveCardsStep';
 
@@ -26,6 +27,7 @@ import styles from './ActionsStep.module.scss';
 const StepTypes = {
   EDIT_TYPE: 'EDIT_TYPE',
   EDIT_COLOR: 'EDIT_COLOR',
+  EDIT_CARD_LIMIT: 'EDIT_CARD_LIMIT',
   SORT: 'SORT',
   EDIT_DEFAULT_CARD_TYPE: 'EDIT_DEFAULT_CARD_TYPE',
   ARCHIVE_CARDS: 'ARCHIVE_CARDS',
@@ -74,6 +76,10 @@ const ActionsStep = React.memo(({ listId, onNameEdit, onCardAdd, onClose }) => {
     openStep(StepTypes.EDIT_COLOR);
   }, [openStep]);
 
+  const handleEditCardLimitClick = useCallback(() => {
+    openStep(StepTypes.EDIT_CARD_LIMIT);
+  }, [openStep]);
+
   const handleEditDefaultCardTypeClick = useCallback(() => {
     openStep(StepTypes.EDIT_DEFAULT_CARD_TYPE);
   }, [openStep]);
@@ -106,6 +112,8 @@ const ActionsStep = React.memo(({ listId, onNameEdit, onCardAdd, onClose }) => {
         );
       case StepTypes.EDIT_COLOR:
         return <EditColorStep listId={listId} onBack={handleBack} onClose={onClose} />;
+      case StepTypes.EDIT_CARD_LIMIT:
+        return <EditCardLimitStep listId={listId} onBack={handleBack} onClose={onClose} />;
       case StepTypes.EDIT_DEFAULT_CARD_TYPE:
         return <EditDefaultCardTypeStep listId={listId} onBack={handleBack} onClose={onClose} />;
       case StepTypes.SORT:
@@ -152,6 +160,11 @@ const ActionsStep = React.memo(({ listId, onNameEdit, onCardAdd, onClose }) => {
           </Menu.Item>
           <Menu.Item className={styles.menuItem} onClick={handleEditDefaultCardTypeClick}>
             {t('action.editDefaultCardType', {
+              context: 'title',
+            })}
+          </Menu.Item>
+          <Menu.Item className={styles.menuItem} onClick={handleEditCardLimitClick}>
+            {t('action.editCardLimit', {
               context: 'title',
             })}
           </Menu.Item>

--- a/client/src/components/lists/List/EditCardLimitStep.jsx
+++ b/client/src/components/lists/List/EditCardLimitStep.jsx
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Button, Form } from 'semantic-ui-react';
+import { Input, Popup } from '../../../lib/custom-ui';
+
+import selectors from '../../../selectors';
+import entryActions from '../../../entry-actions';
+import { useField } from '../../../hooks';
+
+const EditCardLimitStep = React.memo(({ listId, onBack, onClose }) => {
+  const selectListById = useMemo(() => selectors.makeSelectListById(), []);
+
+  const defaultCardLimit = useSelector((state) => selectListById(state, listId).cardLimit ?? 0);
+
+  const dispatch = useDispatch();
+  const [t] = useTranslation();
+  const [value, handleFieldChange] = useField(String(defaultCardLimit));
+
+  const handleSubmit = useCallback(() => {
+    const normalizedValue = value.trim();
+
+    const parsedValue = Number.parseInt(normalizedValue, 10);
+    const cardLimit = Number.isNaN(parsedValue) || parsedValue < 0 ? 0 : parsedValue;
+
+    if (cardLimit !== defaultCardLimit) {
+      dispatch(
+        entryActions.updateList(listId, {
+          cardLimit,
+        }),
+      );
+    }
+
+    onClose();
+  }, [value, defaultCardLimit, dispatch, listId, onClose]);
+
+  return (
+    <>
+      <Popup.Header onBack={onBack}>
+        {t('common.editCardLimit', {
+          context: 'title',
+        })}
+      </Popup.Header>
+      <Popup.Content>
+        <Form onSubmit={handleSubmit}>
+          <Form.Field>
+            <label htmlFor="list-card-limit-field">{t('common.cardLimit')}</label>
+            <Input
+              id="list-card-limit-field"
+              type="number"
+              min="0"
+              step="1"
+              value={value}
+              placeholder={t('common.cardLimitPlaceholder')}
+              onChange={handleFieldChange}
+              autoFocus
+            />
+          </Form.Field>
+          <Button positive content={t('action.save')} />
+          <Button type="button" content={t('action.cancel')} onClick={onClose} />
+        </Form>
+      </Popup.Content>
+    </>
+  );
+});
+
+EditCardLimitStep.propTypes = {
+  listId: PropTypes.string.isRequired,
+  onBack: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default EditCardLimitStep;

--- a/client/src/components/lists/List/index.js
+++ b/client/src/components/lists/List/index.js
@@ -5,6 +5,7 @@
 
 import List from './List';
 import EditDefaultCardTypeStep from './EditDefaultCardTypeStep';
+import EditCardLimitStep from './EditCardLimitStep';
 
 export default List;
-export { EditDefaultCardTypeStep };
+export { EditDefaultCardTypeStep, EditCardLimitStep };

--- a/client/src/locales/ar-YE/core.js
+++ b/client/src/locales/ar-YE/core.js
@@ -165,6 +165,9 @@ export default {
       users: 'المستخدمين',
       viewer: 'مشاهد',
       writeComment: 'اكتب تعليقاً...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -235,6 +238,7 @@ export default {
       unsubscribe: 'إلغاء الاشتراك',
       uploadNewAvatar: 'رفع صورة رمزية جديدة',
       uploadNewImage: 'رفع صورة جديدة',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/bg-BG/core.js
+++ b/client/src/locales/bg-BG/core.js
@@ -170,6 +170,9 @@ export default {
       users: 'Потребители',
       viewer: 'Зрител',
       writeComment: 'Напишете коментар...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -240,6 +243,7 @@ export default {
       unsubscribe: 'Отписване',
       uploadNewAvatar: 'Качване на нов аватар',
       uploadNewImage: 'Качване на ново изображение',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/cs-CZ/core.js
+++ b/client/src/locales/cs-CZ/core.js
@@ -296,6 +296,9 @@ export default {
       visualTaskManagementWithLists: 'Vizuální správa úkolů pomocí seznamů.',
       withoutBaseGroup: 'Bez základní skupiny',
       writeComment: 'Napsat komentář...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -409,6 +412,7 @@ export default {
       unsubscribe: 'Neodebírat',
       uploadNewAvatar: 'Nahrát nový avatar',
       uploadNewImage: 'Nahrát nový obrázek',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/da-DK/core.js
+++ b/client/src/locales/da-DK/core.js
@@ -324,6 +324,9 @@ export default {
       visualTaskManagementWithLists: 'Visuel opgavestyring med lister',
       withoutBaseGroup: 'Uden standardgruppe',
       writeComment: 'Skriv en kommentar...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -437,6 +440,7 @@ export default {
       unsubscribe: 'Opsig abonnement',
       uploadNewAvatar: 'Tilføj nyt profilbillede',
       uploadNewImage: 'Tilføj nyt billede',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/de-DE/core.js
+++ b/client/src/locales/de-DE/core.js
@@ -313,6 +313,9 @@ export default {
       visualTaskManagementWithLists: 'Visuelle Aufgabenverwaltung mit Listen.',
       withoutBaseGroup: 'Ohne Basisgruppe',
       writeComment: 'Kommentar verfassen...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -428,6 +431,7 @@ export default {
       unsubscribe: 'De-abonnieren',
       uploadNewAvatar: 'Neuen Avatar hochladen',
       uploadNewImage: 'Neues Bild hochladen',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/el-GR/core.js
+++ b/client/src/locales/el-GR/core.js
@@ -340,6 +340,9 @@ export default {
       visualTaskManagementWithLists: 'Οπτική διαχείριση εργασιών με λίστες.',
       withoutBaseGroup: 'Χωρίς βασική ομάδα',
       writeComment: 'Γράψτε ένα σχόλιο...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -453,6 +456,7 @@ export default {
       unsubscribe: 'Απεγγραφή',
       uploadNewAvatar: 'Μεταφόρτωση νέου avatar',
       uploadNewImage: 'Μεταφόρτωση νέας εικόνας',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/en-GB/core.js
+++ b/client/src/locales/en-GB/core.js
@@ -332,6 +332,9 @@ export default {
       webhooks: 'Webhooks',
       withoutBaseGroup: 'Without base group',
       writeComment: 'Write a comment...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -450,6 +453,7 @@ export default {
       unsubscribe: 'Unsubscribe',
       uploadNewAvatar: 'Upload new avatar',
       uploadNewImage: 'Upload new image',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -381,6 +381,9 @@ export default {
       visualTaskManagementWithLists: 'Visual task management with lists.',
       withoutBaseGroup: 'Without base group',
       writeComment: 'Write a comment...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -513,6 +516,7 @@ export default {
       unsubscribe: 'Unsubscribe',
       uploadNewAvatar: 'Upload new avatar',
       uploadNewImage: 'Upload new image',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/es-ES/core.js
+++ b/client/src/locales/es-ES/core.js
@@ -318,6 +318,9 @@ export default {
       visualTaskManagementWithLists: 'Gestión visual de tareas con listas',
       withoutBaseGroup: 'Sin grupo base',
       writeComment: 'Escribir un comentario...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -426,6 +429,7 @@ export default {
       unsubscribe: 'Desuscribirse',
       uploadNewAvatar: 'Subir un nuevo avatar',
       uploadNewImage: 'Subir una nueva imagen',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/et-EE/core.js
+++ b/client/src/locales/et-EE/core.js
@@ -322,6 +322,9 @@ export default {
       visualTaskManagementWithLists: 'Visual tööülesande haldamine nimekirjade abil.',
       withoutBaseGroup: 'Ilma põhiklassita',
       writeComment: 'Kirjuta kommentaar...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -435,6 +438,7 @@ export default {
       unsubscribe: 'Tühista tellimus',
       uploadNewAvatar: 'Laadi üles uus avatar',
       uploadNewImage: 'Laadi üles uus pilt',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/fa-IR/core.js
+++ b/client/src/locales/fa-IR/core.js
@@ -167,6 +167,9 @@ export default {
       users: 'کاربران',
       viewer: 'بیننده',
       writeComment: 'نظر بنویسید...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -237,6 +240,7 @@ export default {
       unsubscribe: 'لغو اشتراک',
       uploadNewAvatar: 'آپلود آواتار جدید',
       uploadNewImage: 'آپلود تصویر جدید',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/fi-FI/core.js
+++ b/client/src/locales/fi-FI/core.js
@@ -322,6 +322,9 @@ export default {
       visualTaskManagementWithLists: 'Visuaalinen tehtävien hallinta listoilla.',
       withoutBaseGroup: 'Ilman perusryhmää',
       writeComment: 'Kirjoita kommentti...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -435,6 +438,7 @@ export default {
       unsubscribe: 'Peru tilaus',
       uploadNewAvatar: 'Lataa uusi avatar',
       uploadNewImage: 'Lataa uusi kuva',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -393,6 +393,9 @@ export default {
       visualTaskManagementWithLists: 'Management visuel des tâches avec des listes.',
       withoutBaseGroup: 'Sans groupe de base',
       writeComment: 'Écrire un commentaire...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
     action: {
       activateUser: 'Activer l’utilisateur',
@@ -524,6 +527,7 @@ export default {
       unsubscribe: 'Se désabonner',
       uploadNewAvatar: 'Télécharger un nouvel avatar',
       uploadNewImage: 'Télécharger une nouvelle image',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/hu-HU/core.js
+++ b/client/src/locales/hu-HU/core.js
@@ -168,6 +168,9 @@ export default {
       users: 'Felhasználók',
       viewer: 'Néző',
       writeComment: 'Írjon egy megjegyzést...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -238,6 +241,7 @@ export default {
       unsubscribe: 'Leiratkozás',
       uploadNewAvatar: 'Új avatar feltöltése',
       uploadNewImage: 'Új kép feltöltése',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/id-ID/core.js
+++ b/client/src/locales/id-ID/core.js
@@ -163,6 +163,9 @@ export default {
       users: 'Pengguna',
       viewer: 'Penglihat',
       writeComment: 'Tuliskan komentar...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -230,6 +233,7 @@ export default {
       unsubscribe: 'Berhenti berlangganan',
       uploadNewAvatar: 'Unggah avatar baru',
       uploadNewImage: 'Unggah gambar baru',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/it-IT/core.js
+++ b/client/src/locales/it-IT/core.js
@@ -320,6 +320,9 @@ export default {
       visualTaskManagementWithLists: 'Gestione visiva dei task con liste',
       withoutBaseGroup: 'Senza gruppo base',
       writeComment: 'Scrivi un commento...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -432,6 +435,7 @@ export default {
       unsubscribe: 'Annulla iscrizione',
       uploadNewAvatar: 'Carica nuovo avatar',
       uploadNewImage: 'Carica nuova immagine',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/ja-JP/core.js
+++ b/client/src/locales/ja-JP/core.js
@@ -163,6 +163,9 @@ export default {
       users: 'ユーザー',
       viewer: 'ビューア',
       writeComment: 'コメントを書く…',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -230,6 +233,7 @@ export default {
       unsubscribe: '購読解除',
       uploadNewAvatar: '新しいアバターをアップロード',
       uploadNewImage: '新しい画像をアップロード',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/ko-KR/core.js
+++ b/client/src/locales/ko-KR/core.js
@@ -168,6 +168,9 @@ export default {
       users: '사용자들',
       viewer: '뷰어',
       writeComment: '댓글 작성...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -240,6 +243,7 @@ export default {
       unsubscribe: '구독 취소',
       uploadNewAvatar: '새 아바타 업로드',
       uploadNewImage: '새 이미지 업로드',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/nl-NL/core.js
+++ b/client/src/locales/nl-NL/core.js
@@ -164,6 +164,9 @@ export default {
       users: 'Gebruikers',
       viewer: 'Kijker',
       writeComment: 'Schrijf een opmerking...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -231,6 +234,7 @@ export default {
       unsubscribe: 'Afmelden',
       uploadNewAvatar: 'Nieuwe avatar uploaden',
       uploadNewImage: 'Nieuwe afbeelding uploaden',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/pl-PL/core.js
+++ b/client/src/locales/pl-PL/core.js
@@ -296,6 +296,9 @@ export default {
       visualTaskManagementWithLists: 'Wizualne zarządzanie zadaniami z listami.',
       withoutBaseGroup: 'Bez grupy bazowej',
       writeComment: 'Napisz komentarz...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -409,6 +412,7 @@ export default {
       unsubscribe: 'Odsubskrybuj',
       uploadNewAvatar: 'Wgraj nowy awatar',
       uploadNewImage: 'Wgraj nowy obraz',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/pt-BR/core.js
+++ b/client/src/locales/pt-BR/core.js
@@ -164,6 +164,9 @@ export default {
       users: 'Usuários',
       viewer: 'Visualizador',
       writeComment: 'Escreva um comentário...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -231,6 +234,7 @@ export default {
       unsubscribe: 'Cancelar inscrição',
       uploadNewAvatar: 'Enviar novo avatar',
       uploadNewImage: 'Enviar nova imagem',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/ro-RO/core.js
+++ b/client/src/locales/ro-RO/core.js
@@ -164,6 +164,9 @@ export default {
       users: 'Utilizatori',
       viewer: 'Vizualizator',
       writeComment: 'Scrie un comentariu...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -231,6 +234,7 @@ export default {
       unsubscribe: 'Dezabonați-vă',
       uploadNewAvatar: 'Încărcați un avatar nou',
       uploadNewImage: 'Încărcați o nouă imagine',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/ru-RU/core.js
+++ b/client/src/locales/ru-RU/core.js
@@ -302,6 +302,9 @@ export default {
       visualTaskManagementWithLists: 'Визуальное управление задачами с помощью списков',
       withoutBaseGroup: 'Без основной группы',
       writeComment: 'Напишите комментарий...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -415,6 +418,7 @@ export default {
       unsubscribe: 'Отписаться',
       uploadNewAvatar: 'Загрузить новый аватар',
       uploadNewImage: 'Загрузить новое изображение',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/sk-SK/core.js
+++ b/client/src/locales/sk-SK/core.js
@@ -148,6 +148,9 @@ export default {
       username: 'Používateľské meno',
       users: 'Používatelia',
       writeComment: 'Napísať komentár...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -212,6 +215,7 @@ export default {
       unsubscribe: 'Neodoberať',
       uploadNewAvatar: 'Nahrať nový avatar',
       uploadNewImage: 'Nahrať nový obrázok',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/sr-Cyrl-RS/core.js
+++ b/client/src/locales/sr-Cyrl-RS/core.js
@@ -169,6 +169,9 @@ export default {
       users: 'Корисници',
       viewer: 'Прегледач',
       writeComment: 'Напиши коментар...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -239,6 +242,7 @@ export default {
       unsubscribe: 'Укини претплату',
       uploadNewAvatar: 'Постави нови аватар',
       uploadNewImage: 'Постави нову слику',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/sr-Latn-RS/core.js
+++ b/client/src/locales/sr-Latn-RS/core.js
@@ -166,6 +166,9 @@ export default {
       users: 'Korisnici',
       viewer: 'Pregledač',
       writeComment: 'Napiši komentar...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -236,6 +239,7 @@ export default {
       unsubscribe: 'Ukini pretplatu',
       uploadNewAvatar: 'Postavi novi avatar',
       uploadNewImage: 'Postavi novu sliku',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/sv-SE/core.js
+++ b/client/src/locales/sv-SE/core.js
@@ -146,6 +146,9 @@ export default {
       username: 'Användarnamn',
       users: 'Användare',
       writeComment: 'Skriv en kommentar...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -210,6 +213,7 @@ export default {
       unsubscribe: 'Avprenumerera',
       uploadNewAvatar: 'Ladda upp ny avatar',
       uploadNewImage: 'Ladda upp ny bild',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/tr-TR/core.js
+++ b/client/src/locales/tr-TR/core.js
@@ -147,6 +147,9 @@ export default {
       username: 'kullanıcı adı',
       users: 'kullanıcı',
       writeComment: 'Yorum yazın...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -210,6 +213,7 @@ export default {
       unsubscribe: 'Abonelikten çık',
       uploadNewAvatar: 'Yeni avatar yükle',
       uploadNewImage: 'Yeni resim yükle',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/uk-UA/core.js
+++ b/client/src/locales/uk-UA/core.js
@@ -298,6 +298,9 @@ export default {
       visualTaskManagementWithLists: 'Візуальне управління завданнями за допомогою списків.',
       withoutBaseGroup: 'Без базової групи',
       writeComment: 'Написати коментар...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -411,6 +414,7 @@ export default {
       unsubscribe: 'Відписатися',
       uploadNewAvatar: 'Завантажити новий аватар',
       uploadNewImage: 'Завантажити нове зображення',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/uz-UZ/core.js
+++ b/client/src/locales/uz-UZ/core.js
@@ -143,6 +143,9 @@ export default {
       username: 'Foydalanuvchi nomi',
       users: 'Foydalanuvchilar',
       writeComment: 'Izoh yozish...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -206,6 +209,7 @@ export default {
       unsubscribe: 'Obunani bekor qilish',
       uploadNewAvatar: 'Yangi avatar yuklash',
       uploadNewImage: 'Yangi rasm yuklash',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/zh-CN/core.js
+++ b/client/src/locales/zh-CN/core.js
@@ -155,6 +155,9 @@ export default {
       users: '用户',
       viewer: '视图',
       writeComment: '编写评论...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -223,6 +226,7 @@ export default {
       unsubscribe: '取消关注',
       uploadNewAvatar: '上传新头像',
       uploadNewImage: '上传图片',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };

--- a/client/src/locales/zh-TW/core.js
+++ b/client/src/locales/zh-TW/core.js
@@ -156,6 +156,9 @@ export default {
       users: '使用者',
       viewer: '檢視',
       writeComment: '編寫評論...',
+      cardLimit: 'Card limit',
+      cardLimitPlaceholder: '0 for no limit',
+      editCardLimit_title: 'Edit Card Limit',
     },
 
     action: {
@@ -223,6 +226,7 @@ export default {
       unsubscribe: '取消訂閱',
       uploadNewAvatar: '上傳新頭像',
       uploadNewImage: '上傳圖片',
+      editCardLimit_title: 'Edit Card Limit',
     },
   },
 };


### PR DESCRIPTION
## Summary
- add an edit card limit popup step for lists with a numeric field
- wire the new step into the list actions menu and exports
- provide translations for the new labels and menu entry across locales

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25b9c906483238f8ddb524d8a7c72