### PR TITLE
Add list card count metrics and limit styles

### DIFF
--- a/client/src/components/lists/List/List.module.scss
+++ b/client/src/components/lists/List/List.module.scss
@@ -86,13 +86,17 @@
   }
 
   .header {
+    align-items: flex-start;
+    display: flex;
+    gap: 8px;
     outline: none;
-    padding: 6px 36px 6px 8px;
+    padding: 6px 8px;
     position: relative;
 
     &:hover {
       .headerButton {
         opacity: 1;
+        pointer-events: auto;
       }
 
       .headerIconHidable {
@@ -105,17 +109,26 @@
     cursor: pointer;
   }
 
+  .headerTitle {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
   .headerButton {
     background: none;
     box-shadow: none;
     color: #798d99;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    height: 32px;
     line-height: 32px;
     margin: 0;
     opacity: 0;
     padding: 0;
-    position: absolute;
-    right: 4px;
-    top: 4px;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
     width: 32px;
 
     &:hover {
@@ -126,23 +139,26 @@
 
   .headerIcon {
     color: #798d99;
-    position: absolute;
-    right: 8px;
-    top: 10px;
+    flex: 0 0 auto;
+    transition: opacity 0.2s ease;
   }
 
-  .storyPoints {
-    position: absolute;
-    right: 14px;
-    top: 9px;
-    margin-bottom: 8px;
-    background-color: #FFF;
-    color: #333333;
+  .headerRight {
+    align-items: center;
+    display: flex;
+    flex: 0 0 auto;
+    gap: 6px;
+    margin-left: auto;
   }
 
-  .storyPoints:has(+ i),
-  .storyPoints:has(+ button) {
-    right: 44px;
+  .headerMetrics {
+    display: flex;
+    flex: 0 0 auto;
+    gap: 4px;
+  }
+
+  .headerMetric {
+    margin-bottom: 0;
   }
 
   .headerName {
@@ -174,6 +190,16 @@
     flex-direction: column;
     max-height: calc(100vh - 198px);
     overflow: hidden;
+  }
+
+  .outerWrapperWarning {
+    background: #fbe9e7;
+    box-shadow: 0 0 0 1px rgba(205, 92, 92, 0.35);
+  }
+
+  .outerWrapperBlocking {
+    background: #f5d5d3;
+    box-shadow: 0 0 0 1px rgba(178, 34, 34, 0.45);
   }
 
   .outerWrapperTransitioning {

--- a/client/src/components/lists/List/ListMetricChip.jsx
+++ b/client/src/components/lists/List/ListMetricChip.jsx
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import styles from './ListMetricChip.module.scss';
+
+const ListMetricChip = React.memo(({ filteredCount, totalCount, className }) => {
+  const displayValue = useMemo(() => {
+    const total = Number.isFinite(totalCount) ? totalCount : 0;
+
+    if (Number.isFinite(filteredCount) && filteredCount !== total) {
+      return `${filteredCount}/${total}`;
+    }
+
+    return `${total}`;
+  }, [filteredCount, totalCount]);
+
+  return <span className={classNames(styles.wrapper, className)}>{displayValue}</span>;
+});
+
+ListMetricChip.propTypes = {
+  filteredCount: PropTypes.number,
+  totalCount: PropTypes.number.isRequired,
+  className: PropTypes.string,
+};
+
+ListMetricChip.defaultProps = {
+  filteredCount: null,
+  className: undefined,
+};
+
+export default ListMetricChip;

--- a/client/src/components/lists/List/ListMetricChip.module.scss
+++ b/client/src/components/lists/List/ListMetricChip.module.scss
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+:global(#app) {
+  .wrapper {
+    background: #dce0e4;
+    border-radius: 3px;
+    color: #6a808b;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    line-height: 20px;
+    padding: 0 8px;
+    min-height: 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a list metric chip and use new selectors to show card totals when board settings allow
- prevent adding or dropping cards when the card limit is blocking and close any open add-card form
- restyle the list header badges and apply warning/blocking backgrounds to make limits visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d261387a38832396f74f3b2ebeb5b7