### PR TITLE
Add board settings toggle for card count display

### DIFF
--- a/client/src/components/boards/BoardSettingsModal/GeneralPane/EditInformation.module.scss
+++ b/client/src/components/boards/BoardSettingsModal/GeneralPane/EditInformation.module.scss
@@ -8,6 +8,16 @@
     margin-bottom: 8px;
   }
 
+  .checkboxField {
+    margin-bottom: 8px;
+  }
+
+  .helperText {
+    color: #6b808c;
+    font-size: 12px;
+    margin-bottom: 12px;
+  }
+
   .text {
     color: #444444;
     font-size: 12px;

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -37,6 +37,8 @@ export default {
         'All changes will be automatically saved<br />after connection restored.',
       alphabetically: 'Alphabetically',
       alwaysDisplayCardCreator: 'Always display card creator',
+      showCardCount: 'Show card count',
+      cardCountDisabledInScrum: 'Card count display is disabled when scrum is enabled.',
       archive: 'Archive',
       archiveCard_title: 'Archive Card',
       archiveCards_title: 'Archive Cards',

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -42,6 +42,9 @@ export default {
         'Toutes les modifications seront automatiquement enregistrées<br />une fois la connexion rétablie.',
       alphabetically: 'Alphabétique',
       alwaysDisplayCardCreator: 'Toujours afficher le créateur de la carte',
+      showCardCount: 'Afficher le nombre de cartes',
+      cardCountDisabledInScrum:
+        "L'affichage du nombre de cartes est désactivé lorsque Scrum est activé.",
       archive: 'Archiver',
       archiveCard_title: 'Archiver la carte',
       archiveCards_title: 'Cartes archivées',


### PR DESCRIPTION
## Summary
- add a board settings checkbox to control card count visibility and keep it disabled when scrum is active
- style the general settings pane and add translations for the new option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d271b23b448323b4acd103ec3394df