### PR TITLE
Fix French card limit translations

### DIFF
--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -396,9 +396,9 @@ export default {
       visualTaskManagementWithLists: 'Management visuel des tâches avec des listes.',
       withoutBaseGroup: 'Sans groupe de base',
       writeComment: 'Écrire un commentaire...',
-      cardLimit: 'Card limit',
-      cardLimitPlaceholder: '0 for no limit',
-      editCardLimit_title: 'Edit Card Limit',
+      cardLimit: 'Limite de cartes',
+      cardLimitPlaceholder: '0 pour aucune limite',
+      editCardLimit_title: 'Modifier la limite de cartes',
     },
     action: {
       activateUser: 'Activer l’utilisateur',
@@ -530,7 +530,7 @@ export default {
       unsubscribe: 'Se désabonner',
       uploadNewAvatar: 'Télécharger un nouvel avatar',
       uploadNewImage: 'Télécharger une nouvelle image',
-      editCardLimit_title: 'Edit Card Limit',
+      editCardLimit_title: 'Modifier la limite de cartes',
     },
   },
 };


### PR DESCRIPTION
## Summary
- update the French locale so the card limit action link and dialog strings are translated

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d278b4f1e08323b84b8ba368214ca0