### PR TITLE
Ensure SMTP test errors return JSON responses

### DIFF
--- a/server/api/responses/badGateway.js
+++ b/server/api/responses/badGateway.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+/**
+ * badGateway.js
+ *
+ * A custom response.
+ *
+ * Example usage:
+ * ```
+ *     return res.badGateway();
+ *     // -or-
+ *     return res.badGateway(optionalData);
+ * ```
+ *
+ * Or with actions2:
+ * ```
+ *     exits: {
+ *       somethingHappened: {
+ *         responseType: 'badGateway'
+ *       }
+ *     }
+ * ```
+ *
+ * ```
+ *     throw 'somethingHappened';
+ *     // -or-
+ *     throw { somethingHappened: optionalData }
+ * ```
+ */
+
+const normalizePayload = (payload) => {
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    return payload;
+  }
+
+  return { message: payload };
+};
+
+module.exports = function badGateway(payload) {
+  const { res } = this;
+
+  return res.status(502).json({
+    code: 'E_BAD_GATEWAY',
+    ...normalizePayload(payload),
+  });
+};

--- a/server/api/responses/badRequest.js
+++ b/server/api/responses/badRequest.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+/**
+ * badRequest.js
+ *
+ * A custom response.
+ *
+ * Example usage:
+ * ```
+ *     return res.badRequest();
+ *     // -or-
+ *     return res.badRequest(optionalData);
+ * ```
+ *
+ * Or with actions2:
+ * ```
+ *     exits: {
+ *       somethingHappened: {
+ *         responseType: 'badRequest'
+ *       }
+ *     }
+ * ```
+ *
+ * ```
+ *     throw 'somethingHappened';
+ *     // -or-
+ *     throw { somethingHappened: optionalData }
+ * ```
+ */
+
+const normalizePayload = (payload) => {
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    return payload;
+  }
+
+  return { message: payload };
+};
+
+module.exports = function badRequest(payload) {
+  const { res } = this;
+
+  return res.status(400).json({
+    code: 'E_BAD_REQUEST',
+    ...normalizePayload(payload),
+  });
+};


### PR DESCRIPTION
## Summary
- add dedicated badRequest and badGateway response handlers that serialize payloads as JSON and include error codes
- preserve structured SMTP test error payloads so the administration panel can display failure details

## Testing
- ESLINT_USE_FLAT_CONFIG=false npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3a7630b1483239814d10570d66f52