### PR TITLE
Handle non-JSON API responses

### DIFF
--- a/client/src/api/http.js
+++ b/client/src/api/http.js
@@ -7,36 +7,117 @@ import Config from '../constants/Config';
 
 const http = {};
 
+const buildFormData = (data) => {
+  if (!data) {
+    return undefined;
+  }
+
+  return Object.keys(data).reduce((result, key) => {
+    result.append(key, data[key]);
+
+    return result;
+  }, new FormData());
+};
+
+const createResponseError = (response, text = '', parseError = null, requestInfo = {}) => {
+  const trimmedText = text.trim();
+  const isHtml = trimmedText.startsWith('<');
+  const { status, statusText } = response;
+  const { method: requestMethod, url: requestUrl } = requestInfo;
+
+  let message = statusText || 'Unexpected server response.';
+
+  if (trimmedText && !isHtml) {
+    message = trimmedText;
+  } else if (!statusText && status) {
+    message = `HTTP ${status}`;
+  }
+
+  const error = new Error(message);
+
+  if (status) {
+    error.status = status;
+  }
+
+  if (statusText) {
+    error.statusText = statusText;
+  }
+
+  if (trimmedText && (isHtml || trimmedText !== message)) {
+    error.body = trimmedText;
+  }
+
+  if (parseError) {
+    error.parseError = parseError.message;
+  }
+
+  if (requestMethod) {
+    error.method = requestMethod;
+  }
+
+  if (requestUrl) {
+    error.url = requestUrl;
+  }
+
+  return error;
+};
+
 // TODO: add all methods
 ['GET', 'POST', 'DELETE'].forEach((method) => {
-  http[method.toLowerCase()] = (url, data, headers) => {
-    const formData =
-      data &&
-      Object.keys(data).reduce((result, key) => {
-        result.append(key, data[key]);
-
-        return result;
-      }, new FormData());
-
-    return fetch(`${Config.SERVER_BASE_URL}/api${url}`, {
+  http[method.toLowerCase()] = async (url, data, headers) => {
+    const formData = buildFormData(data);
+    const requestOptions = {
       method,
       headers,
-      body: formData,
       credentials: 'include',
-    })
-      .then((response) =>
-        response.json().then((body) => ({
-          body,
-          isError: response.status !== 200,
-        })),
-      )
-      .then(({ body, isError }) => {
-        if (isError) {
-          throw body;
+    };
+
+    if (formData !== undefined) {
+      requestOptions.body = formData;
+    }
+
+    const response = await fetch(`${Config.SERVER_BASE_URL}/api${url}`, requestOptions);
+    const text = await response.text();
+
+    let body = null;
+    let parseError = null;
+
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch (error) {
+        parseError = error;
+
+        if (response.ok) {
+          const invalidResponseError = new Error('Unable to parse server response.');
+          invalidResponseError.originalError = error;
+          invalidResponseError.responseText = text;
+          invalidResponseError.status = response.status;
+          invalidResponseError.statusText = response.statusText;
+          invalidResponseError.method = method;
+          invalidResponseError.url = url;
+
+          throw invalidResponseError;
+        }
+      }
+    }
+
+    if (!response.ok) {
+      if (body !== null && body !== undefined) {
+        if (typeof body === 'object') {
+          const error = new Error(body.message || 'Request failed.');
+          Object.assign(error, body);
+
+          throw error;
         }
 
-        return body;
-      });
+        throw createResponseError(response, String(body), parseError, { method, url });
+      }
+
+      throw createResponseError(response, text, parseError, { method, url });
+    }
+
+    return body;
   };
 });
 


### PR DESCRIPTION
## Summary
- gracefully parse API responses by falling back to contextual error objects when JSON parsing fails
- return richer Error instances that include HTTP metadata so the UI can display friendlier SMTP test failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b078697c8323bc0fa9422efdca2e