### PR TITLE
Fix SMTP test authentication handling

### DIFF
--- a/client/src/components/common/AdministrationModal/SystemPane/SystemPane.jsx
+++ b/client/src/components/common/AdministrationModal/SystemPane/SystemPane.jsx
@@ -5,11 +5,13 @@
 
 import isEmail from 'validator/lib/isEmail';
 import React, { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { Button, Form, Message, Tab } from 'semantic-ui-react';
 
 import api from '../../../../api';
 import { Input } from '../../../../lib/custom-ui';
+import selectors from '../../../../selectors';
 
 import styles from './SystemPane.module.scss';
 
@@ -48,6 +50,7 @@ const SystemPane = React.memo(() => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  const accessToken = useSelector(selectors.selectAccessToken);
 
   const handleEmailChange = useCallback((event, { value }) => {
     setEmail(value);
@@ -73,9 +76,16 @@ const SystemPane = React.memo(() => {
     setError(null);
 
     try {
-      const response = await api.testSmtp({
-        email: trimmedEmail,
-      });
+      const response = await api.testSmtp(
+        {
+          email: trimmedEmail,
+        },
+        accessToken
+          ? {
+              Authorization: `Bearer ${accessToken}`,
+            }
+          : undefined,
+      );
 
       setResult(response.item);
     } catch (err) {
@@ -83,7 +93,7 @@ const SystemPane = React.memo(() => {
     } finally {
       setIsSubmitting(false);
     }
-  }, [email]);
+  }, [accessToken, email]);
 
   const isEmailValid = isEmail(email.trim());
 

--- a/server/api/policies/is-admin.js
+++ b/server/api/policies/is-admin.js
@@ -4,6 +4,10 @@
  */
 
 module.exports = async function isAuthenticated(req, res, proceed) {
+  if (!req.currentUser) {
+    return res.unauthorized('Access token is missing, invalid or expired');
+  }
+
   if (req.currentUser.role !== User.Roles.ADMIN) {
     return res.notFound(); // Forbidden
   }


### PR DESCRIPTION
## Summary
- prevent the `is-admin` policy from throwing when no user is attached by responding with an unauthorized error
- include the bearer token when triggering the SMTP test from the administration UI so the request is properly authenticated

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3bc0ee65c8323a1c2f48986b81a76