### PR TITLE
Add card link backend support

### DIFF
--- a/server/api/controllers/boards/show-by-slug.js
+++ b/server/api/controllers/boards/show-by-slug.js
@@ -74,6 +74,7 @@ module.exports = {
 
     const cards = await Card.qm.getByListIds(finiteListIds);
     const cardIds = sails.helpers.utils.mapRecords(cards);
+    const cardLinks = cardIds.length > 0 ? await CardLink.qm.getForCardIds(cardIds) : [];
 
     const userIds = _.union(
       sails.helpers.utils.mapRecords(boardMemberships, 'userId'),
@@ -128,6 +129,7 @@ module.exports = {
         labels,
         lists,
         cards,
+        cardLinks,
         cardMemberships,
         cardLabels,
         taskLists,

--- a/server/api/controllers/boards/show.js
+++ b/server/api/controllers/boards/show.js
@@ -64,6 +64,7 @@ module.exports = {
 
     const cards = await Card.qm.getByListIds(finiteListIds);
     const cardIds = sails.helpers.utils.mapRecords(cards);
+    const cardLinks = cardIds.length > 0 ? await CardLink.qm.getForCardIds(cardIds) : [];
 
     const userIds = _.union(
       sails.helpers.utils.mapRecords(boardMemberships, 'userId'),
@@ -118,6 +119,7 @@ module.exports = {
         labels,
         lists,
         cards,
+        cardLinks,
         cardMemberships,
         cardLabels,
         taskLists,

--- a/server/api/controllers/card-links/create.js
+++ b/server/api/controllers/card-links/create.js
@@ -1,0 +1,119 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const { idInput } = require('../../../utils/inputs');
+
+const Errors = {
+  NOT_ENOUGH_RIGHTS: {
+    notEnoughRights: 'Not enough rights',
+  },
+  CARD_NOT_FOUND: {
+    cardNotFound: 'Card not found',
+  },
+  LINKED_CARD_NOT_FOUND: {
+    linkedCardNotFound: 'Linked card not found',
+  },
+  CARD_LINK_ALREADY_EXISTS: {
+    cardLinkAlreadyExists: 'Card link already exists',
+  },
+  CARD_CANNOT_LINK_TO_ITSELF: {
+    cardCannotLinkToItself: 'Card cannot link to itself',
+  },
+};
+
+module.exports = {
+  inputs: {
+    cardId: {
+      ...idInput,
+      required: true,
+    },
+    linkedCardId: {
+      ...idInput,
+      required: true,
+    },
+    type: {
+      type: 'string',
+      required: true,
+      isIn: Object.values(CardLink.Types),
+    },
+  },
+
+  exits: {
+    notEnoughRights: {
+      responseType: 'forbidden',
+    },
+    cardNotFound: {
+      responseType: 'notFound',
+    },
+    linkedCardNotFound: {
+      responseType: 'notFound',
+    },
+    cardLinkAlreadyExists: {
+      responseType: 'conflict',
+    },
+    cardCannotLinkToItself: {
+      responseType: 'unprocessableEntity',
+    },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    if (inputs.cardId === inputs.linkedCardId) {
+      throw Errors.CARD_CANNOT_LINK_TO_ITSELF;
+    }
+
+    const { card, list, board, project } = await sails.helpers.cards
+      .getPathToProjectById(inputs.cardId)
+      .intercept('pathNotFound', () => Errors.CARD_NOT_FOUND);
+
+    const boardMembership = await BoardMembership.qm.getOneByBoardIdAndUserId(
+      board.id,
+      currentUser.id,
+    );
+
+    if (!boardMembership) {
+      throw Errors.CARD_NOT_FOUND; // Forbidden
+    }
+
+    if (boardMembership.role !== BoardMembership.Roles.EDITOR) {
+      throw Errors.NOT_ENOUGH_RIGHTS;
+    }
+
+    const linkedCard = await Card.qm.getOneById(inputs.linkedCardId);
+
+    if (!linkedCard || linkedCard.boardId !== board.id) {
+      throw Errors.LINKED_CARD_NOT_FOUND;
+    }
+
+    const linkedList = await List.qm.getOneById(linkedCard.listId, {
+      boardId: board.id,
+    });
+
+    if (!linkedList) {
+      throw Errors.LINKED_CARD_NOT_FOUND;
+    }
+
+    const cardLink = await sails.helpers.cardLinks.createOne
+      .with({
+        project,
+        board,
+        list,
+        linkedList,
+        values: {
+          card,
+          linkedCard,
+          type: inputs.type,
+        },
+        actorUser: currentUser,
+        request: this.req,
+      })
+      .intercept('cardLinkAlreadyExists', () => Errors.CARD_LINK_ALREADY_EXISTS);
+
+    return {
+      item: cardLink,
+    };
+  },
+};

--- a/server/api/controllers/card-links/delete.js
+++ b/server/api/controllers/card-links/delete.js
@@ -1,0 +1,90 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const { idInput } = require('../../../utils/inputs');
+
+const Errors = {
+  NOT_ENOUGH_RIGHTS: {
+    notEnoughRights: 'Not enough rights',
+  },
+  CARD_LINK_NOT_FOUND: {
+    cardLinkNotFound: 'Card link not found',
+  },
+};
+
+module.exports = {
+  inputs: {
+    id: {
+      ...idInput,
+      required: true,
+    },
+  },
+
+  exits: {
+    notEnoughRights: {
+      responseType: 'forbidden',
+    },
+    cardLinkNotFound: {
+      responseType: 'notFound',
+    },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    const cardLink = await CardLink.qm.getOneById(inputs.id);
+
+    if (!cardLink) {
+      throw Errors.CARD_LINK_NOT_FOUND;
+    }
+
+    const { card, list, board, project } = await sails.helpers.cards
+      .getPathToProjectById(cardLink.cardId)
+      .intercept('pathNotFound', () => Errors.CARD_LINK_NOT_FOUND);
+
+    const boardMembership = await BoardMembership.qm.getOneByBoardIdAndUserId(
+      board.id,
+      currentUser.id,
+    );
+
+    if (!boardMembership) {
+      throw Errors.CARD_LINK_NOT_FOUND; // Forbidden
+    }
+
+    if (boardMembership.role !== BoardMembership.Roles.EDITOR) {
+      throw Errors.NOT_ENOUGH_RIGHTS;
+    }
+
+    const linkedCard = await Card.qm.getOneById(cardLink.linkedCardId);
+
+    if (!linkedCard || linkedCard.boardId !== board.id) {
+      throw Errors.CARD_LINK_NOT_FOUND;
+    }
+
+    const linkedList = await List.qm.getOneById(linkedCard.listId, {
+      boardId: board.id,
+    });
+
+    if (!linkedList) {
+      throw Errors.CARD_LINK_NOT_FOUND;
+    }
+
+    await sails.helpers.cardLinks.deleteOne.with({
+      record: cardLink,
+      card,
+      linkedCard,
+      project,
+      board,
+      list,
+      linkedList,
+      actorUser: currentUser,
+      request: this.req,
+    });
+
+    return {
+      item: cardLink,
+    };
+  },
+};

--- a/server/api/controllers/card-links/search.js
+++ b/server/api/controllers/card-links/search.js
@@ -1,0 +1,142 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const { idInput } = require('../../../utils/inputs');
+
+const LIMIT = 20;
+
+const Errors = {
+  BOARD_NOT_FOUND: {
+    boardNotFound: 'Board not found',
+  },
+  CARD_NOT_FOUND: {
+    cardNotFound: 'Card not found',
+  },
+};
+
+module.exports = {
+  inputs: {
+    boardId: {
+      ...idInput,
+      required: true,
+    },
+    cardId: {
+      ...idInput,
+      required: true,
+    },
+    search: {
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 256,
+      required: true,
+    },
+  },
+
+  exits: {
+    boardNotFound: {
+      responseType: 'notFound',
+    },
+    cardNotFound: {
+      responseType: 'notFound',
+    },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    const { board } = await sails.helpers.boards
+      .getPathToProjectById(inputs.boardId)
+      .intercept('pathNotFound', () => Errors.BOARD_NOT_FOUND);
+
+    const boardMembership = await BoardMembership.qm.getOneByBoardIdAndUserId(
+      board.id,
+      currentUser.id,
+    );
+
+    if (!boardMembership) {
+      throw Errors.BOARD_NOT_FOUND; // Forbidden
+    }
+
+    const card = await Card.qm.getOneById(inputs.cardId);
+
+    if (!card || card.boardId !== board.id) {
+      throw Errors.CARD_NOT_FOUND;
+    }
+
+    const existingCardLinks = await CardLink.qm.getForCardId(card.id);
+
+    const excludedCardIds = new Set([card.id]);
+
+    existingCardLinks.forEach((cardLink) => {
+      if (cardLink.cardId !== card.id) {
+        excludedCardIds.add(cardLink.cardId);
+      }
+
+      if (cardLink.linkedCardId !== card.id) {
+        excludedCardIds.add(cardLink.linkedCardId);
+      }
+    });
+
+    const values = [board.id];
+    let query = `
+      SELECT card.* FROM card
+      WHERE card.board_id = $1
+    `;
+
+    excludedCardIds.forEach((excludedCardId) => {
+      values.push(excludedCardId);
+      query += ` AND card.id <> $${values.length}`;
+    });
+
+    const search = inputs.search.trim();
+
+    if (search.length > 0) {
+      const conditions = [];
+
+      if (search.startsWith('#')) {
+        const number = Number.parseInt(search.slice(1), 10);
+
+        if (!Number.isNaN(number)) {
+          values.push(number);
+          conditions.push(`card.number = $${values.length}`);
+        }
+      }
+
+      if (conditions.length === 0) {
+        values.push(`%${search}%`);
+        conditions.push(`card.name ILIKE $${values.length}`);
+
+        values.push(`%${search}%`);
+        conditions.push(`card.description ILIKE $${values.length}`);
+
+        const number = Number.parseInt(search, 10);
+
+        if (!Number.isNaN(number)) {
+          values.push(number);
+          conditions.push(`card.number = $${values.length}`);
+        }
+      }
+
+      if (conditions.length > 0) {
+        query += ` AND (${conditions.join(' OR ')})`;
+      }
+    }
+
+    query += ` ORDER BY card.name ASC LIMIT ${LIMIT}`;
+
+    const { rows } = await sails.sendNativeQuery(query, values);
+    const cards = rows.map((row) => _.mapKeys(row, (value, key) => _.camelCase(key)));
+
+    const listIds = _.uniq(cards.map((item) => item.listId).filter((listId) => !_.isNil(listId)));
+    const lists = await List.qm.getByIds(listIds);
+
+    return {
+      items: cards,
+      included: {
+        lists,
+      },
+    };
+  },
+};

--- a/server/api/controllers/cards/duplicate.js
+++ b/server/api/controllers/cards/duplicate.js
@@ -93,6 +93,8 @@ module.exports = {
     return {
       item: nextCard,
       included: {
+        cardLinks: [],
+        linkedCards: [],
         cardMemberships,
         cardLabels,
         taskLists,

--- a/server/api/controllers/cards/show-by-number.js
+++ b/server/api/controllers/cards/show-by-number.js
@@ -76,9 +76,25 @@ module.exports = {
     const customFields = await CustomField.qm.getByCustomFieldGroupIds(customFieldGroupIds);
     const customFieldValues = await CustomFieldValue.qm.getByCardId(card.id);
 
+    const cardLinks = await CardLink.qm.getForCardId(card.id);
+
+    const linkedCardIds = new Set();
+    cardLinks.forEach((cardLink) => {
+      if (cardLink.cardId !== card.id) {
+        linkedCardIds.add(cardLink.cardId);
+      }
+
+      if (cardLink.linkedCardId !== card.id) {
+        linkedCardIds.add(cardLink.linkedCardId);
+      }
+    });
+
+    const linkedCards = linkedCardIds.size > 0 ? await Card.qm.getByIds([...linkedCardIds]) : [];
+
     return {
       item: card,
       included: {
+        cardLinks,
         cardMemberships,
         cardLabels,
         taskLists,
@@ -86,6 +102,7 @@ module.exports = {
         customFieldGroups,
         customFields,
         customFieldValues,
+        linkedCards,
         users: sails.helpers.users.presentMany(users, currentUser),
         attachments: sails.helpers.attachments.presentMany(attachments),
       },

--- a/server/api/controllers/cards/show.js
+++ b/server/api/controllers/cards/show.js
@@ -68,9 +68,25 @@ module.exports = {
     const customFields = await CustomField.qm.getByCustomFieldGroupIds(customFieldGroupIds);
     const customFieldValues = await CustomFieldValue.qm.getByCardId(card.id);
 
+    const cardLinks = await CardLink.qm.getForCardId(card.id);
+
+    const linkedCardIds = new Set();
+    cardLinks.forEach((cardLink) => {
+      if (cardLink.cardId !== card.id) {
+        linkedCardIds.add(cardLink.cardId);
+      }
+
+      if (cardLink.linkedCardId !== card.id) {
+        linkedCardIds.add(cardLink.linkedCardId);
+      }
+    });
+
+    const linkedCards = linkedCardIds.size > 0 ? await Card.qm.getByIds([...linkedCardIds]) : [];
+
     return {
       item: card,
       included: {
+        cardLinks,
         cardMemberships,
         cardLabels,
         taskLists,
@@ -78,6 +94,7 @@ module.exports = {
         customFieldGroups,
         customFields,
         customFieldValues,
+        linkedCards,
         users: sails.helpers.users.presentMany(users, currentUser),
         attachments: sails.helpers.attachments.presentMany(attachments),
       },

--- a/server/api/helpers/card-links/create-one.js
+++ b/server/api/helpers/card-links/create-one.js
@@ -1,0 +1,107 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports = {
+  inputs: {
+    values: {
+      type: 'ref',
+      required: true,
+    },
+    project: {
+      type: 'ref',
+      required: true,
+    },
+    board: {
+      type: 'ref',
+      required: true,
+    },
+    list: {
+      type: 'ref',
+      required: true,
+    },
+    linkedList: {
+      type: 'ref',
+      required: true,
+    },
+    actorUser: {
+      type: 'ref',
+      required: true,
+    },
+    request: {
+      type: 'ref',
+    },
+  },
+
+  exits: {
+    cardLinkAlreadyExists: {},
+  },
+
+  async fn(inputs) {
+    const { values } = inputs;
+
+    let cardLink;
+    try {
+      cardLink = await CardLink.qm.createOne({
+        type: values.type,
+        cardId: values.card.id,
+        linkedCardId: values.linkedCard.id,
+      });
+    } catch (error) {
+      if (error.code === 'E_UNIQUE') {
+        throw 'cardLinkAlreadyExists';
+      }
+
+      throw error;
+    }
+
+    sails.sockets.broadcast(
+      `board:${inputs.board.id}`,
+      'cardLinkCreate',
+      {
+        item: cardLink,
+      },
+      inputs.request,
+    );
+
+    const webhooks = await Webhook.qm.getAll();
+
+    const lists = _.uniqBy([inputs.list, inputs.linkedList], 'id');
+    const cards = _.uniqBy([values.card, values.linkedCard], 'id');
+
+    sails.helpers.utils.sendWebhooks.with({
+      webhooks,
+      event: Webhook.Events.CARD_LINK_CREATE,
+      buildData: () => ({
+        item: cardLink,
+        included: {
+          projects: [inputs.project],
+          boards: [inputs.board],
+          lists,
+          cards,
+        },
+      }),
+      user: inputs.actorUser,
+    });
+
+    await sails.helpers.actions.createOne.with({
+      webhooks,
+      values: {
+        type: Action.Types.ADD_CARD_LINK_TO_CARD,
+        data: {
+          card: _.pick(values.card, ['id', 'name']),
+          linkedCard: _.pick(values.linkedCard, ['id', 'name']),
+          type: cardLink.type,
+        },
+        user: inputs.actorUser,
+        card: values.card,
+      },
+      project: inputs.project,
+      board: inputs.board,
+      list: inputs.list,
+    });
+
+    return cardLink;
+  },
+};

--- a/server/api/helpers/card-links/delete-one.js
+++ b/server/api/helpers/card-links/delete-one.js
@@ -1,0 +1,100 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports = {
+  inputs: {
+    record: {
+      type: 'ref',
+      required: true,
+    },
+    card: {
+      type: 'ref',
+      required: true,
+    },
+    linkedCard: {
+      type: 'ref',
+      required: true,
+    },
+    project: {
+      type: 'ref',
+      required: true,
+    },
+    board: {
+      type: 'ref',
+      required: true,
+    },
+    list: {
+      type: 'ref',
+      required: true,
+    },
+    linkedList: {
+      type: 'ref',
+      required: true,
+    },
+    actorUser: {
+      type: 'ref',
+      required: true,
+    },
+    request: {
+      type: 'ref',
+    },
+  },
+
+  async fn(inputs) {
+    const cardLink = await CardLink.qm.deleteOne(inputs.record.id);
+
+    if (!cardLink) {
+      return cardLink;
+    }
+
+    sails.sockets.broadcast(
+      `board:${inputs.board.id}`,
+      'cardLinkDelete',
+      {
+        item: cardLink,
+      },
+      inputs.request,
+    );
+
+    const webhooks = await Webhook.qm.getAll();
+
+    const lists = _.uniqBy([inputs.list, inputs.linkedList], 'id');
+    const cards = _.uniqBy([inputs.card, inputs.linkedCard], 'id');
+
+    sails.helpers.utils.sendWebhooks.with({
+      webhooks,
+      event: Webhook.Events.CARD_LINK_DELETE,
+      buildData: () => ({
+        item: cardLink,
+        included: {
+          projects: [inputs.project],
+          boards: [inputs.board],
+          lists,
+          cards,
+        },
+      }),
+      user: inputs.actorUser,
+    });
+
+    await sails.helpers.actions.createOne.with({
+      webhooks,
+      values: {
+        type: Action.Types.REMOVE_CARD_LINK_FROM_CARD,
+        data: {
+          card: _.pick(inputs.card, ['id', 'name']),
+          linkedCard: _.pick(inputs.linkedCard, ['id', 'name']),
+          type: cardLink.type,
+        },
+        user: inputs.actorUser,
+        card: inputs.card,
+      },
+      project: inputs.project,
+      board: inputs.board,
+      list: inputs.list,
+    });
+
+    return cardLink;
+  },
+};

--- a/server/api/hooks/query-methods/models/CardLink.js
+++ b/server/api/hooks/query-methods/models/CardLink.js
@@ -1,0 +1,95 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const defaultFind = (criteria, { sort = 'id' } = {}) => CardLink.find(criteria).sort(sort);
+
+/* Query methods */
+
+const create = (arrayOfValues) => CardLink.createEach(arrayOfValues).fetch();
+
+const createOne = (values) => CardLink.create({ ...values }).fetch();
+
+const getByIds = (ids) => defaultFind(ids);
+
+const getOneById = (id) => CardLink.findOne({ id });
+
+const getByCardId = (cardId) =>
+  defaultFind({
+    cardId,
+  });
+
+const getByCardIds = (cardIds) =>
+  defaultFind({
+    cardId: cardIds,
+  });
+
+const getByLinkedCardId = (linkedCardId) =>
+  defaultFind({
+    linkedCardId,
+  });
+
+const getByLinkedCardIds = (linkedCardIds) =>
+  defaultFind({
+    linkedCardId: linkedCardIds,
+  });
+
+const getForCardId = (cardId) =>
+  defaultFind({
+    or: [
+      {
+        cardId,
+      },
+      {
+        linkedCardId: cardId,
+      },
+    ],
+  });
+
+const getForCardIds = (cardIds) =>
+  defaultFind({
+    or: [
+      {
+        cardId: cardIds,
+      },
+      {
+        linkedCardId: cardIds,
+      },
+    ],
+  });
+
+const getOneByCardIds = (cardId, linkedCardId) =>
+  CardLink.findOne({
+    or: [
+      {
+        cardId,
+        linkedCardId,
+      },
+      {
+        cardId: linkedCardId,
+        linkedCardId: cardId,
+      },
+    ],
+  });
+
+// eslint-disable-next-line no-underscore-dangle
+const delete_ = (criteria) => CardLink.destroy(criteria).fetch();
+
+const deleteOne = (criteria) => CardLink.destroyOne(criteria);
+
+module.exports = {
+  create,
+  createOne,
+  getByIds,
+  getOneById,
+  getByCardId,
+  getByCardIds,
+  getByLinkedCardId,
+  getByLinkedCardIds,
+  getForCardId,
+  getForCardIds,
+  getOneByCardIds,
+  deleteOne,
+  delete: delete_,
+};

--- a/server/api/models/Action.js
+++ b/server/api/models/Action.js
@@ -15,6 +15,8 @@ const Types = {
   MOVE_CARD: 'moveCard',
   ADD_MEMBER_TO_CARD: 'addMemberToCard',
   REMOVE_MEMBER_FROM_CARD: 'removeMemberFromCard',
+  ADD_CARD_LINK_TO_CARD: 'addCardLinkToCard',
+  REMOVE_CARD_LINK_FROM_CARD: 'removeCardLinkFromCard',
   COMPLETE_TASK: 'completeTask',
   UNCOMPLETE_TASK: 'uncompleteTask',
 };

--- a/server/api/models/Card.js
+++ b/server/api/models/Card.js
@@ -148,6 +148,14 @@ module.exports = {
       collection: 'Action',
       via: 'cardId',
     },
+    outgoingCardLinks: {
+      collection: 'CardLink',
+      via: 'cardId',
+    },
+    incomingCardLinks: {
+      collection: 'CardLink',
+      via: 'linkedCardId',
+    },
     sprints: {
       collection: 'Sprint',
       via: 'cardId',

--- a/server/api/models/CardLink.js
+++ b/server/api/models/CardLink.js
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+/**
+ * CardLink.js
+ *
+ * @description :: A model definition represents a database table/collection.
+ * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
+ */
+
+const Types = {
+  RELATES_TO: 'relatesTo',
+  BLOCKS: 'blocks',
+  DUPLICATES: 'duplicates',
+};
+
+module.exports = {
+  Types,
+
+  attributes: {
+    type: {
+      type: 'string',
+      isIn: Object.values(Types),
+      required: true,
+    },
+
+    cardId: {
+      model: 'Card',
+      required: true,
+      columnName: 'card_id',
+    },
+
+    linkedCardId: {
+      model: 'Card',
+      required: true,
+      columnName: 'linked_card_id',
+    },
+  },
+
+  tableName: 'card_link',
+};

--- a/server/api/models/Webhook.js
+++ b/server/api/models/Webhook.js
@@ -42,6 +42,9 @@ const Events = {
   CARD_MEMBERSHIP_CREATE: 'cardMembershipCreate',
   CARD_MEMBERSHIP_DELETE: 'cardMembershipDelete',
 
+  CARD_LINK_CREATE: 'cardLinkCreate',
+  CARD_LINK_DELETE: 'cardLinkDelete',
+
   COMMENT_CREATE: 'commentCreate',
   COMMENT_UPDATE: 'commentUpdate',
   COMMENT_DELETE: 'commentDelete',

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -160,6 +160,8 @@ module.exports.routes = {
   'DELETE /api/cards/:cardId/card-memberships/userId::userId': 'card-memberships/delete',
   'POST /api/cards/:cardId/card-labels': 'card-labels/create',
   'DELETE /api/cards/:cardId/card-labels/labelId::labelId': 'card-labels/delete',
+  'POST /api/cards/:cardId/card-links': 'card-links/create',
+  'DELETE /api/card-links/:id': 'card-links/delete',
 
   'POST /api/cards/:cardId/task-lists': 'task-lists/create',
   'GET /api/task-lists/:id': 'task-lists/show',
@@ -198,6 +200,7 @@ module.exports.routes = {
   'DELETE /api/comments/:id': 'comments/delete',
 
   'GET /api/boards/:boardId/actions': 'actions/index-in-board',
+  'GET /api/boards/:boardId/card-links/search': 'card-links/search',
   'GET /api/cards/:cardId/actions': 'actions/index-in-card',
 
   'GET /api/notifications': 'notifications/index',

--- a/server/db/migrations/20250919120000_create_card_links.js
+++ b/server/db/migrations/20250919120000_create_card_links.js
@@ -1,0 +1,27 @@
+exports.up = async (knex) => {
+  await knex.schema.createTable('card_link', (table) => {
+    table.bigInteger('id').primary().defaultTo(knex.raw('next_id()'));
+    table.bigInteger('card_id').notNullable();
+    table.bigInteger('linked_card_id').notNullable();
+    table.string('type').notNullable();
+    table.timestamp('created_at', true);
+    table.timestamp('updated_at', true);
+
+    table.foreign('card_id').references('id').inTable('card').onDelete('CASCADE');
+    table.foreign('linked_card_id').references('id').inTable('card').onDelete('CASCADE');
+
+    table.index('card_id');
+    table.index('linked_card_id');
+    table.index('type');
+  });
+
+  await knex.raw(
+    'ALTER TABLE card_link ADD CONSTRAINT card_link_card_id_not_equal CHECK (card_id <> linked_card_id)',
+  );
+
+  await knex.raw(
+    'CREATE UNIQUE INDEX card_link_unique_pair ON card_link (LEAST(card_id, linked_card_id), GREATEST(card_id, linked_card_id))',
+  );
+};
+
+exports.down = (knex) => knex.schema.dropTable('card_link');


### PR DESCRIPTION
## Summary
- create the `card_link` table and Sails model to store typed relationships between cards
- add CardLink query helpers, socket/webhook hooks, and controller endpoints for creating, deleting, and searching links
- update card, list, and board payloads to hydrate incoming/outgoing link data and register the new REST routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dee056964c832393fd7f1e4c984381