### PR TITLE
Fix linked card navigation path for linked cards

### DIFF
--- a/client/src/components/cards/CardModal/LinkedCards/LinkedCardItem.jsx
+++ b/client/src/components/cards/CardModal/LinkedCards/LinkedCardItem.jsx
@@ -3,23 +3,53 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button, Icon } from 'semantic-ui-react';
+import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
 
 import history from '../../../../history';
+import selectors from '../../../../selectors';
+import Paths from '../../../../constants/Paths';
 
 import styles from './LinkedCards.module.scss';
 
 const LinkedCardItem = React.memo(
   ({ cardLinkId, linkedCardId, name, typeLabel, canEdit, onRemove, isRemoving, removeLabel }) => {
+    const [t] = useTranslation();
+    const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
+    const selectBoardById = useMemo(() => selectors.makeSelectBoardById(), []);
+    const selectProjectById = useMemo(() => selectors.makeSelectProjectById(), []);
+
+    const linkedCard = useSelector((state) => selectCardById(state, linkedCardId));
+    const linkedBoard = useSelector((state) =>
+      linkedCard && linkedCard.boardId ? selectBoardById(state, linkedCard.boardId) : null,
+    );
+    const linkedProject = useSelector((state) =>
+      linkedBoard ? selectProjectById(state, linkedBoard.projectId) : null,
+    );
+
+    const linkedCardPath = useMemo(() => {
+      if (linkedCard && linkedProject) {
+        return Paths.CARDS.replace(':projectCode', linkedProject.code).replace(
+          ':number',
+          linkedCard.number,
+        );
+      }
+
+      return `/cards/${linkedCardId}`;
+    }, [linkedCard, linkedProject, linkedCardId]);
+
+    const displayName = name || t('common.unnamedCard');
+
     const handleOpen = useCallback(
       (event) => {
         event.preventDefault();
-        history.push(`/cards/${linkedCardId}`);
+        history.push(linkedCardPath);
       },
-      [linkedCardId],
+      [linkedCardPath],
     );
 
     const handleRemove = useCallback(() => {
@@ -29,7 +59,7 @@ const LinkedCardItem = React.memo(
     return (
       <div className={styles.listRow}>
         <button type="button" className={styles.cardButton} onClick={handleOpen}>
-          {name || '—'}
+          {displayName}
         </button>
         <div className={styles.typeCell}>{typeLabel}</div>
         <div className={styles.actionsCell}>

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -114,6 +114,7 @@ export default {
       canOnlyViewBoard: 'Can only view the board.',
       cardActions_title: 'Card Actions',
       cardNotFound_title: 'Card Not Found',
+      unnamedCard: 'Untitled card',
       cardsOnThisListAreAvailableToAllBoardMembers:
         'Cards on this list are available to all board members.',
       cardsOnThisListAreCompleteAndReadyToBeArchived:

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -123,6 +123,7 @@ export default {
       canOnlyViewBoard: 'Peut uniquement voir le tableau.',
       cardActions_title: 'Actions sur la carte',
       cardNotFound_title: 'Carte non trouvée',
+      unnamedCard: 'Carte sans nom',
       cardsOnThisListAreAvailableToAllBoardMembers:
         'Les cartes de cette liste sont disponibles pour tous les membres du tableau.',
       cardsOnThisListAreCompleteAndReadyToBeArchived:


### PR DESCRIPTION
## Summary
- derive linked card routes from their project code and number when opening linked cards
- localize the fallback label shown for unnamed linked cards in English and French

## Testing
- ESLINT_USE_FLAT_CONFIG=false npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0fcbe0f088323ad15cc42ee254a07