### PR TITLE
fix: translate linked cards texts to French

### DIFF
--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -342,6 +342,25 @@ export default {
       stopwatch: 'Minuteur',
       story: 'Story',
       storyPoints: 'Story points',
+      /* Translators: Header shown above the linked cards section in the card modal. */
+      linkedCards: 'Cartes liées',
+      /* Translators: Helper text shown when no linked cards exist yet. */
+      noLinkedCards: 'Pas encore de cartes liées.',
+      /* Translators: Labels for each relationship option available when linking cards. */
+      cardLinkTypes: {
+        /* Translators: Indicates that the cards are loosely connected. */
+        related: 'En relation',
+        /* Translators: Indicates that this card blocks progress on the linked card. */
+        blocks: 'Bloque',
+        /* Translators: Indicates that this card is blocked by the linked card. */
+        blockedBy: 'Bloqué par',
+        /* Translators: Indicates that this card depends on the linked card. */
+        dependsOn: 'Dépend de',
+        /* Translators: Indicates that the cards duplicate each other. */
+        duplicates: 'Duplique',
+        /* Translators: Indicates that this card is duplicated by the linked card. */
+        duplicatedBy: 'Dupliqué par',
+      },
       subscribeToCardWhenCommenting: 'S’abonner à la carte lors de la rédaction d’un commentaire',
       subscribeToMyOwnCardsByDefault: "M'abonner à mes propres cartes par défaut",
       taskActions_title: 'Actions de tâche',


### PR DESCRIPTION
## Summary
- add missing French translations for the linked cards section labels and helper text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0ff2a1b9c832382eac0bb24dc411c