### PR TITLE
Fix popup and linked cards console warnings

### DIFF
--- a/client/src/components/cards/Card/Card.jsx
+++ b/client/src/components/cards/Card/Card.jsx
@@ -25,7 +25,7 @@ import ActionsStep from './ActionsStep';
 import styles from './Card.module.scss';
 import globalStyles from '../../../styles.module.scss';
 
-const Card = React.memo(({ id, isInline }) => {
+const Card = React.memo(({ id, isInline = false }) => {
   const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
   const selectIsCardWithIdRecent = useMemo(() => selectors.makeSelectIsCardWithIdRecent(), []);
   const selectListById = useMemo(() => selectors.makeSelectListById(), []);
@@ -154,11 +154,7 @@ const Card = React.memo(({ id, isInline }) => {
 
 Card.propTypes = {
   id: PropTypes.string.isRequired,
-  isInline: PropTypes.bool,
-};
-
-Card.defaultProps = {
-  isInline: false,
+  isInline: PropTypes.bool, // eslint-disable-line react/require-default-props
 };
 
 export default Card;


### PR DESCRIPTION
## Summary
- avoid memo defaultProps on Card and linked card modal content while keeping prop validation
- stabilize the linked card search selector with dequal to stop the Redux rerender warning
- rework the popup trigger to rely on refs instead of findDOMNode and keep callbacks in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1020ae700832391fd6afa8c46bee7