### PR TITLE
Fix ReduxRouter default props usage

### DIFF
--- a/client/src/lib/redux-router/ReduxRouter.jsx
+++ b/client/src/lib/redux-router/ReduxRouter.jsx
@@ -10,7 +10,9 @@ import { Router } from 'react-router-dom';
 
 import { handleLocationChange } from './actions';
 
-function ReduxRouter({ children, history, selector, basename }) {
+const defaultSelector = ({ router }) => router;
+
+function ReduxRouter({ children, history, selector = defaultSelector, basename = undefined }) {
   const state = useSelector(selector);
   const dispatch = useDispatch();
 
@@ -39,13 +41,8 @@ function ReduxRouter({ children, history, selector, basename }) {
 ReduxRouter.propTypes = {
   children: PropTypes.element.isRequired,
   history: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  selector: PropTypes.func,
-  basename: PropTypes.string,
-};
-
-ReduxRouter.defaultProps = {
-  selector: ({ router }) => router,
-  basename: undefined,
+  selector: PropTypes.func, // eslint-disable-line react/require-default-props
+  basename: PropTypes.string, // eslint-disable-line react/require-default-props
 };
 
 export default ReduxRouter;


### PR DESCRIPTION
## Summary
- replace `ReduxRouter` defaultProps with default function arguments to satisfy React's upcoming changes
- provide a shared default selector function and document optional props with lint exceptions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e104d5b0c4832388eb557821ab4b6a