### PR TITLE
Add swimlane type support for boards

### DIFF
--- a/server/api/controllers/boards/create.js
+++ b/server/api/controllers/boards/create.js
@@ -38,6 +38,10 @@ module.exports = {
       type: 'string',
       allowNull: true,
     },
+    swimlaneType: {
+      type: 'string',
+      isIn: Object.values(Board.SwimlaneTypes),
+    },
     importType: {
       type: 'string',
       isIn: Object.values(Board.ImportTypes),
@@ -116,7 +120,7 @@ module.exports = {
       }
     }
 
-    const values = _.pick(inputs, ['position', 'name', 'defaultCardTypeId']);
+    const values = _.pick(inputs, ['position', 'name', 'defaultCardTypeId', 'swimlaneType']);
 
     if (values.defaultCardTypeId) {
       const cardType = await sails.helpers.cardTypes.getOrCreateForProject

--- a/server/api/controllers/boards/update.js
+++ b/server/api/controllers/boards/update.js
@@ -40,6 +40,10 @@ module.exports = {
       type: 'string',
       allowNull: true,
     },
+    swimlaneType: {
+      type: 'string',
+      isIn: Object.values(Board.SwimlaneTypes),
+    },
     limitCardTypesToDefaultOne: {
       type: 'boolean',
       allowNull: true,
@@ -87,6 +91,7 @@ module.exports = {
         'defaultView',
         'defaultCardType',
         'defaultCardTypeId',
+        'swimlaneType',
         'limitCardTypesToDefaultOne',
         'alwaysDisplayCardCreator',
         'showCardCount',
@@ -106,6 +111,7 @@ module.exports = {
       'defaultView',
       'defaultCardType',
       'defaultCardTypeId',
+      'swimlaneType',
       'limitCardTypesToDefaultOne',
       'alwaysDisplayCardCreator',
       'isSubscribed',

--- a/server/api/models/Board.js
+++ b/server/api/models/Board.js
@@ -24,9 +24,17 @@ const ImportTypes = {
   PLANNER: 'planner',
 };
 
+const SwimlaneTypes = {
+  NONE: 'none',
+  MEMBERS: 'members',
+  LABELS: 'labels',
+  EPICS: 'epics',
+};
+
 module.exports = {
   Views,
   ImportTypes,
+  SwimlaneTypes,
 
   attributes: {
     //  ╔═╗╦═╗╦╔╦╗╦╔╦╗╦╦  ╦╔═╗╔═╗
@@ -59,6 +67,12 @@ module.exports = {
     defaultCardTypeId: {
       model: 'CardType',
       columnName: 'default_card_type_id',
+    },
+    swimlaneType: {
+      type: 'string',
+      isIn: Object.values(SwimlaneTypes),
+      defaultsTo: SwimlaneTypes.NONE,
+      columnName: 'swimlane_type',
     },
     limitCardTypesToDefaultOne: {
       type: 'boolean',

--- a/server/db/migrations/20250920120000_add_swimlane_type_to_board.js
+++ b/server/db/migrations/20250920120000_add_swimlane_type_to_board.js
@@ -1,0 +1,15 @@
+exports.up = async (knex) => {
+  await knex.schema.table('board', (table) => {
+    table.string('swimlane_type').notNullable().defaultTo('none');
+  });
+
+  await knex('board').update({ swimlane_type: 'none' });
+};
+
+exports.down = async (knex) => {
+  await knex('board').update({ swimlane_type: 'none' });
+
+  await knex.schema.table('board', (table) => {
+    table.dropColumn('swimlane_type');
+  });
+};

--- a/server/tests/boards.update.test.js
+++ b/server/tests/boards.update.test.js
@@ -50,7 +50,10 @@ describe('boards/update controller', () => {
       },
     };
 
-    global.Board = { Views: { kanban: 'kanban', table: 'table' } };
+    global.Board = {
+      Views: { kanban: 'kanban', table: 'table' },
+      SwimlaneTypes: { NONE: 'none', MEMBERS: 'members', LABELS: 'labels', EPICS: 'epics' },
+    };
 
     // Require controller after setting globals it depends on (Board, _,...)
     // to avoid ReferenceError at module evaluation time.

--- a/server/tests/show-card-count-and-card-limit.test.js
+++ b/server/tests/show-card-count-and-card-limit.test.js
@@ -17,6 +17,7 @@ global._ = lodash;
 
 global.Board = global.Board || {
   Views: { KANBAN: 'kanban', GRID: 'grid', LIST: 'list' },
+  SwimlaneTypes: { NONE: 'none', MEMBERS: 'members', LABELS: 'labels', EPICS: 'epics' },
   qm: {},
 };
 
@@ -75,6 +76,7 @@ describe('showCardCount and cardLimit updates', () => {
 
     global.Board = {
       Views: { KANBAN: 'kanban', GRID: 'grid', LIST: 'list' },
+      SwimlaneTypes: { NONE: 'none', MEMBERS: 'members', LABELS: 'labels', EPICS: 'epics' },
       qm: {
         getByProjectId: jest.fn(),
       },


### PR DESCRIPTION
## Summary
- add a migration that introduces the non-null `swimlane_type` column on boards
- expose `SwimlaneTypes` and the `swimlaneType` attribute on the board model
- allow board create and update flows to accept and persist the swimlane type value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e786a2ac688323b0a42d815a0c56e3