### PR TITLE
Add swimlane type defaults to board model

### DIFF
--- a/client/src/constants/Enums.js
+++ b/client/src/constants/Enums.js
@@ -67,6 +67,13 @@ export const BoardContexts = {
   TRASH: 'trash',
 };
 
+export const BoardSwimlaneTypes = {
+  NONE: 'none',
+  MEMBERS: 'members',
+  LABELS: 'labels',
+  EPICS: 'epics',
+};
+
 export const BoardMembershipRoles = {
   EDITOR: 'editor',
   VIEWER: 'viewer',

--- a/client/src/models/Board.js
+++ b/client/src/models/Board.js
@@ -10,7 +10,7 @@ import buildSearchParts from '../utils/build-search-parts';
 import { isListFinite } from '../utils/record-helpers';
 import ActionTypes from '../constants/ActionTypes';
 import Config from '../constants/Config';
-import { BoardContexts, BoardViews } from '../constants/Enums';
+import { BoardContexts, BoardSwimlaneTypes, BoardViews } from '../constants/Enums';
 
 const prepareFetchedBoard = (board) => ({
   ...board,
@@ -18,6 +18,7 @@ const prepareFetchedBoard = (board) => ({
   context: BoardContexts.BOARD,
   view: board.defaultView,
   search: '',
+  swimlaneType: board.swimlaneType ?? BoardSwimlaneTypes.NONE,
 });
 
 export default class extends BaseModel {
@@ -35,6 +36,9 @@ export default class extends BaseModel {
     alwaysDisplayCardCreator: attr(),
     showCardCount: attr({
       getDefault: () => false,
+    }),
+    swimlaneType: attr({
+      getDefault: () => BoardSwimlaneTypes.NONE,
     }),
     context: attr(),
     view: attr(),


### PR DESCRIPTION
## Summary
- add BoardSwimlaneTypes constants to the client enums
- include swimlaneType defaults in the Board model and fetched board preparation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e78b06b90c8323a4eb5565fe9a8609