### PR TITLE
Add swimlane selectors for filtered list cards

### DIFF
--- a/client/src/selectors/lists.js
+++ b/client/src/selectors/lists.js
@@ -8,7 +8,7 @@ import { createSelector } from 'redux-orm';
 import orm from '../orm';
 import { selectPath } from './router';
 import { isLocalId } from '../utils/local-id';
-import { BoardContexts, ListTypes } from '../constants/Enums';
+import { BoardContexts, BoardSwimlaneTypes, ListTypes } from '../constants/Enums';
 
 export const makeSelectListById = () =>
   createSelector(
@@ -120,6 +120,41 @@ export const makeSelectFilteredCardIdsByListId = () =>
   );
 
 export const selectFilteredCardIdsByListId = makeSelectFilteredCardIdsByListId();
+
+export const makeSelectUniqueFilteredCardIdsByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    ({ List }, id) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      return listModel.getUniqueFilteredCardIds();
+    },
+  );
+
+export const selectUniqueFilteredCardIdsByListId = makeSelectUniqueFilteredCardIdsByListId();
+
+export const makeSelectSwimlaneLanesByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    (_, __, swimlaneType) => swimlaneType,
+    ({ List }, id, swimlaneType) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      return listModel.getSwimlaneDescriptors(swimlaneType || BoardSwimlaneTypes.NONE);
+    },
+  );
+
+export const selectSwimlaneLanesByListId = makeSelectSwimlaneLanesByListId();
 
 export const makeSelectListIdBySlug = () =>
   createSelector(

--- a/client/tests/list-selectors.test.js
+++ b/client/tests/list-selectors.test.js
@@ -12,9 +12,11 @@ import {
   makeSelectFilteredCardIdsByListId,
   makeSelectIsCardLimitReachedByListId,
   makeSelectIsCardLimitBlockingByListId,
+  makeSelectSwimlaneLanesByListId,
+  makeSelectUniqueFilteredCardIdsByListId,
 } from '../src/selectors/lists';
 import { makeSelectProjectById } from '../src/selectors/projects';
-import { BoardViews, ListTypes } from '../src/constants/Enums';
+import { BoardSwimlaneTypes, BoardViews, ListTypes } from '../src/constants/Enums';
 
 const PROJECT_ID = 'project-1';
 const BOARD_ID = 'board-1';
@@ -25,9 +27,13 @@ const createState = ({
   cardLimit = 0,
   searchTerm = '',
   cards = [],
+  users = [],
+  labels = [],
+  epics = [],
+  boardFilters = {},
 } = {}) => {
   const session = orm.session(orm.getEmptyState());
-  const { Project, Board, List, Card } = session;
+  const { Project, Board, List, Card, User, Label, Epic } = session;
 
   Project.create({
     id: PROJECT_ID,
@@ -36,7 +42,25 @@ const createState = ({
     useScrum,
   });
 
-  Board.create({
+  users.forEach((user) => {
+    User.create(user);
+  });
+
+  labels.forEach((label) => {
+    Label.create({
+      boardId: BOARD_ID,
+      ...label,
+    });
+  });
+
+  epics.forEach((epic) => {
+    Epic.create({
+      projectId: PROJECT_ID,
+      ...epic,
+    });
+  });
+
+  const boardModel = Board.create({
     id: BOARD_ID,
     name: 'Board',
     slug: 'board',
@@ -48,6 +72,18 @@ const createState = ({
     search: searchTerm,
   });
 
+  if (boardFilters.userIds) {
+    boardFilters.userIds.forEach((userId) => {
+      boardModel.filterUsers.add(userId);
+    });
+  }
+
+  if (boardFilters.labelIds) {
+    boardFilters.labelIds.forEach((labelId) => {
+      boardModel.filterLabels.add(labelId);
+    });
+  }
+
   List.create({
     id: LIST_ID,
     name: 'List',
@@ -58,13 +94,36 @@ const createState = ({
     cardLimit,
   });
 
-  cards.forEach((name, index) => {
-    Card.create({
-      id: `card-${index + 1}`,
+  cards.forEach((rawCard, index) => {
+    const cardData =
+      typeof rawCard === 'string'
+        ? { id: `card-${index + 1}`, name: rawCard }
+        : rawCard;
+
+    const {
+      id = `card-${index + 1}`,
       name,
-      position: index + 1,
+      position = index + 1,
+      memberIds = [],
+      labelIds = [],
+      epicId = null,
+    } = cardData;
+
+    const cardModel = Card.create({
+      id,
+      name,
+      position,
       boardId: BOARD_ID,
       listId: LIST_ID,
+      epicId,
+    });
+
+    memberIds.forEach((memberId) => {
+      cardModel.users.add(memberId);
+    });
+
+    labelIds.forEach((labelId) => {
+      cardModel.labels.add(labelId);
     });
   });
 
@@ -109,6 +168,100 @@ describe('list selectors', () => {
 
     expect(selectIsLimitReached(state, LIST_ID)).toBe(true);
     expect(selectIsLimitBlocking(state, LIST_ID)).toBe(true);
+  });
+
+  test('groups filtered cards into member swimlanes with duplication and unassigned lane', () => {
+    const state = createState({
+      users: [
+        { id: 'user-1', name: 'Alice' },
+        { id: 'user-2', name: 'Bob' },
+      ],
+      cards: [
+        {
+          id: 'card-1',
+          name: 'Multi member card',
+          memberIds: ['user-1', 'user-2'],
+        },
+        {
+          id: 'card-2',
+          name: 'Orphan card',
+        },
+      ],
+    });
+
+    const selectSwimlanes = makeSelectSwimlaneLanesByListId();
+    const selectUniqueIds = makeSelectUniqueFilteredCardIdsByListId();
+
+    expect(selectSwimlanes(state, LIST_ID, BoardSwimlaneTypes.MEMBERS)).toEqual([
+      { id: 'member:user-1', cardIds: ['card-1'] },
+      { id: 'member:user-2', cardIds: ['card-1'] },
+      { id: 'unassigned', cardIds: ['card-2'] },
+    ]);
+    expect(selectUniqueIds(state, LIST_ID)).toEqual(['card-1', 'card-2']);
+  });
+
+  test('groups filtered cards into label swimlanes and keeps unassigned lane when needed', () => {
+    const state = createState({
+      labels: [
+        { id: 'label-1', name: 'Frontend', position: 1 },
+        { id: 'label-2', name: 'Backend', position: 2 },
+      ],
+      cards: [
+        {
+          id: 'card-1',
+          name: 'Tagged card',
+          labelIds: ['label-1', 'label-2'],
+        },
+        {
+          id: 'card-2',
+          name: 'No label card',
+        },
+      ],
+    });
+
+    const selectSwimlanes = makeSelectSwimlaneLanesByListId();
+
+    expect(selectSwimlanes(state, LIST_ID, BoardSwimlaneTypes.LABELS)).toEqual([
+      { id: 'label:label-1', cardIds: ['card-1'] },
+      { id: 'label:label-2', cardIds: ['card-1'] },
+      { id: 'unassigned', cardIds: ['card-2'] },
+    ]);
+  });
+
+  test('respects board filters when building epic swimlanes', () => {
+    const state = createState({
+      labels: [
+        { id: 'label-1', name: 'Frontend', position: 1 },
+      ],
+      epics: [
+        { id: 'epic-1', name: 'Release A' },
+        { id: 'epic-2', name: 'Release B' },
+      ],
+      cards: [
+        {
+          id: 'card-1',
+          name: 'Included card',
+          epicId: 'epic-1',
+          labelIds: ['label-1'],
+        },
+        {
+          id: 'card-2',
+          name: 'Filtered out card',
+          epicId: 'epic-2',
+        },
+      ],
+      boardFilters: {
+        labelIds: ['label-1'],
+      },
+    });
+
+    const selectSwimlanes = makeSelectSwimlaneLanesByListId();
+    const selectUniqueIds = makeSelectUniqueFilteredCardIdsByListId();
+
+    expect(selectSwimlanes(state, LIST_ID, BoardSwimlaneTypes.EPICS)).toEqual([
+      { id: 'epic:epic-1', cardIds: ['card-1'] },
+    ]);
+    expect(selectUniqueIds(state, LIST_ID)).toEqual(['card-1']);
   });
 });
 


### PR DESCRIPTION
## Summary
- add helper methods on the list model to derive unique filtered cards and swimlane descriptors
- expose memoized selectors that provide swimlane lanes and unique filtered ids to the UI
- expand list selector tests to cover swimlane scenarios, duplication, unassigned lanes, and board filters

## Testing
- npm run client:test -- list-selectors
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e78e06c3788323b005d1e944e4188c