### PR TITLE
Implement list swimlane rendering and unique card metrics

### DIFF
--- a/client/src/components/cards/DraggableCard/DraggableCard.jsx
+++ b/client/src/components/cards/DraggableCard/DraggableCard.jsx
@@ -15,40 +15,45 @@ import Card from '../Card';
 
 import styles from './DraggableCard.module.scss';
 
-const DraggableCard = React.memo(({ id, index, className = undefined, ...props }) => {
-  const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
+const DraggableCard = React.memo(
+  ({ id, index, laneKey = null, className = undefined, ...props }) => {
+    const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
 
-  const card = useSelector((state) => selectCardById(state, id));
+    const card = useSelector((state) => selectCardById(state, id));
 
-  const canDrag = useSelector((state) => {
-    const boardMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
-    return !!boardMembership && boardMembership.role === BoardMembershipRoles.EDITOR;
-  });
+    const canDrag = useSelector((state) => {
+      const boardMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
+      return !!boardMembership && boardMembership.role === BoardMembershipRoles.EDITOR;
+    });
 
-  return (
-    <Draggable
-      draggableId={`card:${id}`}
-      index={index}
-      isDragDisabled={!card.isPersisted || !canDrag}
-    >
-      {({ innerRef, draggableProps, dragHandleProps }) => (
-        <div
-          {...draggableProps} // eslint-disable-line react/jsx-props-no-spreading
-          {...dragHandleProps} // eslint-disable-line react/jsx-props-no-spreading
-          ref={innerRef}
-          className={classNames(styles.wrapper, className)}
-        >
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <Card {...props} id={id} />
-        </div>
-      )}
-    </Draggable>
-  );
-});
+    const draggableId = laneKey ? `card:${id}:lane:${laneKey}` : `card:${id}`;
+
+    return (
+      <Draggable
+        draggableId={draggableId}
+        index={index}
+        isDragDisabled={!card.isPersisted || !canDrag}
+      >
+        {({ innerRef, draggableProps, dragHandleProps }) => (
+          <div
+            {...draggableProps} // eslint-disable-line react/jsx-props-no-spreading
+            {...dragHandleProps} // eslint-disable-line react/jsx-props-no-spreading
+            ref={innerRef}
+            className={classNames(styles.wrapper, className)}
+          >
+            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+            <Card {...props} id={id} />
+          </div>
+        )}
+      </Draggable>
+    );
+  },
+);
 
 DraggableCard.propTypes = {
   id: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
+  laneKey: PropTypes.string,
   className: PropTypes.string,
 };
 

--- a/client/src/components/lists/List/List.module.scss
+++ b/client/src/components/lists/List/List.module.scss
@@ -79,10 +79,35 @@
     }
   }
 
+  .cardsInnerWrapperWithSwimlanes {
+    width: 290px;
+
+    &:hover {
+      width: 290px;
+    }
+  }
+
   .cardsOuterWrapper {
     padding: 0 8px;
     white-space: normal;
     width: 272px;
+  }
+
+  .cardsOuterWrapperWithSwimlanes {
+    padding-bottom: 12px;
+  }
+
+  .swimlanes {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  @media (min-width: 520px) {
+    .swimlanes {
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
   }
 
   .header {

--- a/client/src/components/lists/List/ListMetricChip.jsx
+++ b/client/src/components/lists/List/ListMetricChip.jsx
@@ -9,22 +9,24 @@ import classNames from 'classnames';
 
 import styles from './ListMetricChip.module.scss';
 
-const ListMetricChip = React.memo(({ filteredCount = null, totalCount, className = undefined }) => {
-  const displayValue = useMemo(() => {
-    const total = Number.isFinite(totalCount) ? totalCount : 0;
+const ListMetricChip = React.memo(
+  ({ filteredUniqueCount = null, totalCount, className = undefined }) => {
+    const displayValue = useMemo(() => {
+      const total = Number.isFinite(totalCount) ? totalCount : 0;
 
-    if (Number.isFinite(filteredCount) && filteredCount !== total) {
-      return `${filteredCount}/${total}`;
-    }
+      if (Number.isFinite(filteredUniqueCount) && filteredUniqueCount !== total) {
+        return `${filteredUniqueCount}/${total}`;
+      }
 
-    return `${total}`;
-  }, [filteredCount, totalCount]);
+      return `${total}`;
+    }, [filteredUniqueCount, totalCount]);
 
-  return <span className={classNames(styles.wrapper, className)}>{displayValue}</span>;
-});
+    return <span className={classNames(styles.wrapper, className)}>{displayValue}</span>;
+  },
+);
 
 ListMetricChip.propTypes = {
-  filteredCount: PropTypes.number,
+  filteredUniqueCount: PropTypes.number,
   totalCount: PropTypes.number.isRequired,
   className: PropTypes.string,
 };

--- a/client/src/components/lists/List/ListSwimlane.jsx
+++ b/client/src/components/lists/List/ListSwimlane.jsx
@@ -1,0 +1,210 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Droppable } from '@hello-pangea/dnd';
+
+import selectors from '../../../selectors';
+import DroppableTypes from '../../../constants/DroppableTypes';
+import { BoardSwimlaneTypes } from '../../../constants/Enums';
+import DraggableCard from '../../cards/DraggableCard';
+import AddCard from '../../cards/AddCard';
+import PlusMathIcon from '../../../assets/images/plus-math-icon.svg?react';
+import UserAvatar from '../../users/UserAvatar';
+import LabelChip from '../../labels/LabelChip';
+import EpicChip from '../../epics/EpicChip';
+
+import styles from './ListSwimlane.module.scss';
+
+const UNKNOWN_LABEL = 'Unknown';
+
+const ListSwimlane = React.memo(
+  ({
+    lane,
+    laneKey,
+    listId,
+    swimlaneType,
+    canAddCard,
+    canDropCard,
+    isLimitBlocking,
+    isListPersisted,
+    isAddCardOpened,
+    onCardCreate,
+    onAddCardOpen,
+    onAddCardClose,
+  }) => {
+    const [t] = useTranslation();
+
+    const selectUserById = useMemo(() => selectors.makeSelectUserById(), []);
+    const selectLabelById = useMemo(() => selectors.makeSelectLabelById(), []);
+    const selectEpicById = useMemo(() => selectors.makeSelectEpicById(), []);
+
+    const laneParts = useMemo(() => laneKey.split(':'), [laneKey]);
+    const laneEntityId = laneParts.length > 1 ? laneParts[1] : null;
+
+    const user = useSelector((state) => selectUserById(state, laneEntityId));
+    const label = useSelector((state) => selectLabelById(state, laneEntityId));
+    const epic = useSelector((state) => selectEpicById(state, laneEntityId));
+
+    const laneCardIds = useMemo(() => lane.cardIds || [], [lane.cardIds]);
+    const laneCardCount = useMemo(() => new Set(laneCardIds).size, [laneCardIds]);
+
+    const handleAddCardClick = useCallback(() => {
+      if (isLimitBlocking || !isListPersisted) {
+        return;
+      }
+
+      onAddCardOpen(laneKey);
+    }, [isLimitBlocking, isListPersisted, onAddCardOpen, laneKey]);
+
+    const handleAddCardClose = useCallback(() => {
+      onAddCardClose();
+    }, [onAddCardClose]);
+
+    const handleCardCreate = useCallback(
+      (data, autoOpen) => {
+        onCardCreate(data, autoOpen);
+      },
+      [onCardCreate],
+    );
+
+    const fallbackTitle = useMemo(
+      () => (
+        <span className={styles.titleText}>
+          {t('common.unknown', { defaultValue: UNKNOWN_LABEL })}
+        </span>
+      ),
+      [t],
+    );
+
+    const laneTitleNode = useMemo(() => {
+      if (laneKey === 'unassigned') {
+        return (
+          <span className={styles.unassignedBadge}>
+            {t('common.unassigned', { defaultValue: 'Unassigned' })}
+          </span>
+        );
+      }
+
+      switch (swimlaneType) {
+        case BoardSwimlaneTypes.MEMBERS: {
+          if (!laneEntityId || !user) {
+            return fallbackTitle;
+          }
+
+          return (
+            <span className={styles.memberTitle}>
+              <UserAvatar id={laneEntityId} size="small" className={styles.memberAvatar} />
+              <span className={styles.memberName}>{user.name || user.username}</span>
+            </span>
+          );
+        }
+        case BoardSwimlaneTypes.LABELS: {
+          if (!laneEntityId || !label) {
+            return fallbackTitle;
+          }
+
+          return (
+            <span className={styles.labelTitle}>
+              <LabelChip id={laneEntityId} size="small" />
+            </span>
+          );
+        }
+        case BoardSwimlaneTypes.EPICS: {
+          if (!laneEntityId || !epic) {
+            return fallbackTitle;
+          }
+
+          return (
+            <span className={styles.epicTitle}>
+              <EpicChip id={laneEntityId} size="small" />
+            </span>
+          );
+        }
+        default:
+          return <span className={styles.titleText}>{laneKey}</span>;
+      }
+    }, [laneKey, swimlaneType, laneEntityId, user, label, epic, fallbackTitle, t]);
+
+    const droppableId = useMemo(() => `list:${listId}:lane:${laneKey}`, [laneKey, listId]);
+
+    return (
+      <div className={styles.wrapper}>
+        <div className={styles.header}>
+          <div className={styles.headerTitle}>{laneTitleNode}</div>
+          {Number.isFinite(laneCardCount) && (
+            <span className={styles.headerCount}>{laneCardCount}</span>
+          )}
+        </div>
+        <Droppable
+          droppableId={droppableId}
+          type={DroppableTypes.CARD}
+          isDropDisabled={!isListPersisted || !canDropCard || isLimitBlocking}
+        >
+          {({ innerRef, droppableProps, placeholder }) => (
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            <div {...droppableProps} ref={innerRef} className={styles.cards}>
+              {laneCardIds.map((cardId, cardIndex) => (
+                <DraggableCard
+                  key={`${laneKey}:${cardId}`}
+                  id={cardId}
+                  index={cardIndex}
+                  laneKey={laneKey}
+                  className={styles.card}
+                />
+              ))}
+              {placeholder ? <div className={styles.placeholder}>{placeholder}</div> : null}
+              {canAddCard && !isLimitBlocking && (
+                <AddCard
+                  isOpened={isAddCardOpened}
+                  className={styles.addCard}
+                  listId={listId}
+                  onCreate={handleCardCreate}
+                  onClose={handleAddCardClose}
+                />
+              )}
+            </div>
+          )}
+        </Droppable>
+        {canAddCard && !isLimitBlocking && !isAddCardOpened && (
+          <button
+            type="button"
+            disabled={!isListPersisted || isLimitBlocking}
+            className={styles.addCardButton}
+            onClick={handleAddCardClick}
+          >
+            <PlusMathIcon className={styles.addCardButtonIcon} />
+            <span className={styles.addCardButtonText}>
+              {laneCardCount > 0 ? t('action.addAnotherCard') : t('action.addCard')}
+            </span>
+          </button>
+        )}
+      </div>
+    );
+  },
+);
+
+ListSwimlane.propTypes = {
+  lane: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    cardIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }).isRequired,
+  laneKey: PropTypes.string.isRequired,
+  listId: PropTypes.string.isRequired,
+  swimlaneType: PropTypes.oneOf(Object.values(BoardSwimlaneTypes)).isRequired,
+  canAddCard: PropTypes.bool.isRequired,
+  canDropCard: PropTypes.bool.isRequired,
+  isLimitBlocking: PropTypes.bool.isRequired,
+  isListPersisted: PropTypes.bool.isRequired,
+  isAddCardOpened: PropTypes.bool.isRequired,
+  onCardCreate: PropTypes.func.isRequired,
+  onAddCardOpen: PropTypes.func.isRequired,
+  onAddCardClose: PropTypes.func.isRequired,
+};
+
+export default ListSwimlane;

--- a/client/src/components/lists/List/ListSwimlane.module.scss
+++ b/client/src/components/lists/List/ListSwimlane.module.scss
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+.wrapper {
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+}
+
+.header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.headerTitle {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.headerCount {
+  background: rgba(23, 57, 77, 0.08);
+  border-radius: 12px;
+  color: #17394d;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 4px 8px;
+}
+
+.titleText {
+  color: #17394d;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.memberTitle {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+}
+
+.memberAvatar {
+  display: inline-flex;
+}
+
+.memberName {
+  color: #17394d;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.labelTitle,
+.epicTitle {
+  display: inline-flex;
+}
+
+.unassignedBadge {
+  background: rgba(9, 30, 66, 0.1);
+  border-radius: 999px;
+  color: #54606a;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  line-height: 1;
+  padding: 4px 10px;
+  text-transform: uppercase;
+}
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 1px;
+}
+
+.card {
+  margin: 0;
+}
+
+.placeholder {
+  margin-bottom: 8px;
+}
+
+.addCard {
+  margin-bottom: 8px;
+}
+
+.addCardButton {
+  background: #dfe3e6;
+  border: none;
+  color: #6b808c;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-start;
+  padding: 8px;
+  text-align: left;
+  width: 100%;
+
+  &:hover:not(:disabled) {
+    background: #c3cbd0;
+    color: #17394d;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.addCardButtonIcon {
+  height: 18px;
+  width: 18px;
+}
+
+.addCardButtonText {
+  font-size: 14px;
+  line-height: 20px;
+}


### PR DESCRIPTION
## Summary
- update list rendering to branch on swimlane configuration and consume unique card selectors
- add a dedicated ListSwimlane component with supporting styles for lane layout and badges
- adjust DraggableCard identifiers to include lane keys and refresh metric chip handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7919e405883239833c27cbb8f1bf3