### PR TITLE
Add saga lane context tests and document swimlane modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@
 - **Rich Markdown Support**: Write beautifully formatted card descriptions with a powerful markdown editor
 - **Flexible Notifications**: Get alerts through 100+ providers, fully customizable to your workflow
 - **Configurable List Counters**: Enable per-board list card counters to track filtered versus total cards at a glance; counters are automatically disabled when Scrum mode is active
+- **Board Swimlane Modes**: Group each board by members, labels, or epics and see cards duplicated across relevant swimlanes for complete visual coverage
 - **Seamless Authentication**: Single sign-on with OpenID Connect integration
 - **Multilingual & Easy to Translate**: Full internationalization support for a global audience
 - **Stable List Slugs**: Lists have optional `slug` identifiers for reliable API queries, unaffected by renaming
+
+### Board swimlane preferences
+
+Every board can switch between three grouping modes—**Members**, **Labels**, and **Epics**—from the board action menu or preferences pane. Cards automatically appear in each lane that matches their assignments, and an additional **Unassigned** lane keeps items without a matching member, label, or epic in sight so work never disappears when grouped visually.
 
 ## Personal Project Owners
 

--- a/client/src/sagas/core/services/cards.js
+++ b/client/src/sagas/core/services/cards.js
@@ -120,7 +120,7 @@ export function* handleCardsUpdate(cards, activities) {
   yield put(actions.handleCardsUpdate(cards, activities));
 }
 
-function* applyLaneContextAfterCreate(card, laneContext, boardSwimlaneType) {
+export function* applyLaneContextAfterCreate(card, laneContext, boardSwimlaneType) {
   if (laneContext === undefined) {
     return;
   }

--- a/client/src/styles.module.scss
+++ b/client/src/styles.module.scss
@@ -359,6 +359,11 @@
 }
 
 :global(#app) {
+  &.dragging,
+  &.dragScrolling {
+    touch-action: none;
+  }
+
   &.dragging > * {
     pointer-events: none;
   }

--- a/client/tests/cards-sagas.test.js
+++ b/client/tests/cards-sagas.test.js
@@ -1,0 +1,161 @@
+jest.mock('../src/constants/Config', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../src/assets/images/deleted-user.png', () => 'deleted-user.png', {
+  virtual: true,
+});
+
+jest.mock('../src/lib/redux-router', () => ({
+  __esModule: true,
+  LOCATION_CHANGE_HANDLE: 'LOCATION_CHANGE_HANDLE',
+}));
+
+jest.mock('../src/api', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../src/i18n', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { all, put, select } from 'redux-saga/effects';
+
+import entryActions from '../src/entry-actions';
+import selectors from '../src/selectors';
+import { BoardSwimlaneTypes } from '../src/constants/Enums';
+import { applyLaneContextAfterCreate } from '../src/sagas/core/services/cards';
+
+describe('cards sagas - applyLaneContextAfterCreate', () => {
+  const cardId = 'card-1';
+
+  test('returns immediately when no lane context is provided', () => {
+    const iterator = applyLaneContextAfterCreate({ id: cardId }, undefined, BoardSwimlaneTypes.MEMBERS);
+
+    const firstStep = iterator.next();
+    expect(firstStep.done).toBe(true);
+    expect(firstStep.value).toBeUndefined();
+  });
+
+  test('clears all member assignments when moving to the unassigned lane', () => {
+    const iterator = applyLaneContextAfterCreate({ id: cardId }, null, BoardSwimlaneTypes.MEMBERS);
+
+    expect(iterator.next().value).toEqual(select(selectors.selectUserIdsByCardId, cardId));
+
+    const removalEffect = iterator.next(['user-1', 'user-2']).value;
+    expect(removalEffect).toEqual(
+      all([
+        put(entryActions.removeUserFromCard('user-1', cardId)),
+        put(entryActions.removeUserFromCard('user-2', cardId)),
+      ]),
+    );
+
+    expect(iterator.next().done).toBe(true);
+  });
+
+  test('stops early when there is nothing to clear from a lane', () => {
+    const iterator = applyLaneContextAfterCreate({ id: cardId }, null, BoardSwimlaneTypes.MEMBERS);
+
+    expect(iterator.next().value).toEqual(select(selectors.selectUserIdsByCardId, cardId));
+
+    const completionStep = iterator.next([]);
+    expect(completionStep.done).toBe(true);
+    expect(completionStep.value).toBeUndefined();
+  });
+
+  test('treats the explicit unassigned lane context like a null value', () => {
+    const iterator = applyLaneContextAfterCreate(
+      { id: cardId },
+      { type: 'unassigned' },
+      BoardSwimlaneTypes.LABELS,
+    );
+
+    expect(iterator.next().value).toEqual(select(selectors.selectLabelIdsByCardId, cardId));
+
+    const removalEffect = iterator.next(['label-1']).value;
+    expect(removalEffect).toEqual(
+      all([put(entryActions.removeLabelFromCard('label-1', cardId))]),
+    );
+
+    expect(iterator.next().done).toBe(true);
+  });
+
+  test('removes the epic assignment when dropping into the unassigned epic lane', () => {
+    const iterator = applyLaneContextAfterCreate(
+      { id: cardId, epicId: 'epic-42' },
+      null,
+      BoardSwimlaneTypes.EPICS,
+    );
+
+    expect(iterator.next().value).toEqual(
+      put(entryActions.updateCard(cardId, { epicId: null })),
+    );
+    expect(iterator.next().done).toBe(true);
+  });
+
+  test('adds the card to the targeted member lane', () => {
+    const iterator = applyLaneContextAfterCreate(
+      { id: cardId },
+      { type: 'member', value: 'user-99' },
+      BoardSwimlaneTypes.MEMBERS,
+    );
+
+    expect(iterator.next().value).toEqual(
+      put(entryActions.addUserToCard('user-99', cardId)),
+    );
+    expect(iterator.next().done).toBe(true);
+  });
+
+  test('adds the card to the targeted label lane', () => {
+    const iterator = applyLaneContextAfterCreate(
+      { id: cardId },
+      { type: 'label', value: 'label-77' },
+      BoardSwimlaneTypes.LABELS,
+    );
+
+    expect(iterator.next().value).toEqual(
+      put(entryActions.addLabelToCard('label-77', cardId)),
+    );
+    expect(iterator.next().done).toBe(true);
+  });
+
+  test('updates the epic assignment when moving into a new epic lane', () => {
+    const iterator = applyLaneContextAfterCreate(
+      { id: cardId, epicId: null },
+      { type: 'epic', value: 'epic-007' },
+      BoardSwimlaneTypes.EPICS,
+    );
+
+    expect(iterator.next().value).toEqual(
+      put(entryActions.updateCard(cardId, { epicId: 'epic-007' })),
+    );
+    expect(iterator.next().done).toBe(true);
+  });
+
+  test('skips redundant epic updates when the target already matches', () => {
+    const iterator = applyLaneContextAfterCreate(
+      { id: cardId, epicId: 'epic-007' },
+      { type: 'epic', value: 'epic-007' },
+      BoardSwimlaneTypes.EPICS,
+    );
+
+    const firstStep = iterator.next();
+    expect(firstStep.done).toBe(true);
+    expect(firstStep.value).toBeUndefined();
+  });
+
+  test('ignores malformed lane context values', () => {
+    const iterator = applyLaneContextAfterCreate(
+      { id: cardId },
+      'unexpected-value',
+      BoardSwimlaneTypes.MEMBERS,
+    );
+
+    const firstStep = iterator.next();
+    expect(firstStep.done).toBe(true);
+    expect(firstStep.value).toBeUndefined();
+  });
+});

--- a/client/tests/list-selectors.test.js
+++ b/client/tests/list-selectors.test.js
@@ -263,6 +263,26 @@ describe('list selectors', () => {
     ]);
     expect(selectUniqueIds(state, LIST_ID)).toEqual(['card-1']);
   });
+
+  test('returns no swimlanes when the board is not grouped or no cards match', () => {
+    const selectSwimlanes = makeSelectSwimlaneLanesByListId();
+
+    const emptyState = createState();
+    expect(selectSwimlanes(emptyState, LIST_ID, BoardSwimlaneTypes.MEMBERS)).toEqual([]);
+
+    const populatedState = createState({
+      cards: [
+        {
+          id: 'card-1',
+          name: 'Card without grouping',
+          memberIds: ['user-1'],
+        },
+      ],
+    });
+
+    expect(selectSwimlanes(populatedState, LIST_ID, BoardSwimlaneTypes.NONE)).toEqual([]);
+    expect(selectSwimlanes(populatedState, LIST_ID, undefined)).toEqual([]);
+  });
 });
 
 describe('project selector', () => {


### PR DESCRIPTION
## Summary
- add targeted saga coverage for swimlane lane-context handling and expand list selector tests
- document board swimlane modes and adjust drag styles for stacked droppables

## Testing
- npm run client:test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e804f9a7ec83238b9e98ca959de4de